### PR TITLE
Fix some typos

### DIFF
--- a/docs/index.bs
+++ b/docs/index.bs
@@ -422,7 +422,7 @@ For example:
 
 <div class=example>
 ```http
-GET /.well-known/webid HTTPS/1.1
+GET /.well-known/webid HTTP/1.1
 Host: idp.example
 Accept: application/json
 Sec-FedCM-CSRF: random_value
@@ -464,7 +464,7 @@ For example:
 
 <div class=example>
 ```http
-GET /accounts_list.php HTTPS/1.1
+GET /accounts_list.php HTTP/1.1
 Host: idp.example
 Accept: application/json
 Cookie: 0x23223
@@ -530,7 +530,7 @@ For example:
 
 <div class=example>
 ```http
-GET /client_medata.php?client_id=1234 HTTPS/1.1
+GET /client_medata.php?client_id=1234 HTTP/1.1
 Host: idp.example
 Accept: application/json
 Sec-FedCM-CSRF: random_value
@@ -587,9 +587,9 @@ For example:
 
 <div class=example>
 ```http
-POST /webid_token_endpoint HTTPS/1.1
+POST /webid_token_endpoint HTTP/1.1
 Host: idp.example
-Referrer: rp.example
+Referer: rp.example
 Content-Type: application/json
 Cookie: 0x23223
 Sec-FedCM-CSRF: random_value
@@ -1567,8 +1567,8 @@ Mitigates:
     * [[#data-compromise]],
     * [[#cross-site-correlation]]
 
-Currently, IDPs require that an RP pre-registers and agrees to specific terms before the IDP will issue an ID token to them. T
-his conflicts with [the previous mitigation](#self-presentation), but can provide a measure of RP accountability.
+Currently, IDPs require that an RP pre-registers and agrees to specific terms before the IDP will issue an ID token to them.
+This conflicts with [the previous mitigation](#self-presentation), but can provide a measure of RP accountability.
 
 ### 2FA
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,9 +4,9 @@
   <title>Federated Credential Management API</title>
   <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
-  <meta content="Bikeshed version 4f053d00e, updated Tue Aug 10 14:13:32 2021 -0700" name="generator">
+  <meta content="Bikeshed version d7036035b, updated Fri Oct 8 17:07:11 2021 -0700" name="generator">
   <link href="http://wicg.github.io/FedCM" rel="canonical">
-  <meta content="d29d6f60b252e9057097c85b8b6ae2aba4e6ab57" name="document-revision">
+  <meta content="6f273b83bb2915018fd56449c3b53a6111d256af" name="document-revision">
 <style>
 dl.domintro dt {
     font-family: Menlo, Consolas, "DejaVu Sans Mono", Monaco, monospace;
@@ -261,6 +261,16 @@ figcaption:not(.no-marker)::before {
 }
 
 .dfn-paneled { cursor: pointer; }
+</style>
+<style>/* style-issues */
+
+a[href].issue-return {
+    float: right;
+    float: inline-end;
+    color: var(--issueheading-text);
+    font-weight: bold;
+    text-decoration: none;
+}
 </style>
 <style>/* style-md-lists */
 
@@ -581,7 +591,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Federated Credential Management API</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2021-10-13">13 October 2021</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="profile-and-date"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2021-10-14">14 October 2021</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1100,12 +1110,12 @@ site they’re visiting. A goal of anti-tracking policy is to promote <a data-li
    <p>The well-known discovery endpoint is an endpoint located at the <a data-link-type="dfn" href="#idp" id="ref-for-idp⑤">IDP</a>'s <code>.well-known/webid</code> and serves as a discovery device to other endpoints provided by the <a data-link-type="dfn" href="#idp" id="ref-for-idp⑥">IDP</a>.</p>
    <p>The well-known discovery endpoint is fetched (a) <strong>without</strong> cookies and (b) <strong>with</strong> a special <a href="#Sec-FedCM-CSR">§ 6.6 Sec-FedCM-CSR</a> header.</p>
    <p>For example:</p>
-   <div class="example" id="example-71b0eec8">
-    <a class="self-link" href="#example-71b0eec8"></a> 
-<pre class="language-http highlight">GET /.well-known/webid HTTPS/1.1
-Host: idp.example
-Accept: application/json
-Sec-FedCM-CSRF: random_value
+   <div class="example" id="example-b84b3f84">
+    <a class="self-link" href="#example-b84b3f84"></a> 
+<pre class="language-http highlight"><c- nf>GET</c-> <c- nn>/.well-known/webid</c-> <c- kr>HTTP</c-><c- o>/</c-><c- m>1.1</c->
+<c- e>Host</c-><c- o>:</c-> <c- l>idp.example</c->
+<c- e>Accept</c-><c- o>:</c-> <c- l>application/json</c->
+<c- e>Sec-FedCM-CSRF</c-><c- o>:</c-> <c- l>random_value</c->
 </pre>
    </div>
    <p>The file is parsed expecting the following properties:</p>
@@ -1134,13 +1144,13 @@ Sec-FedCM-CSRF: random_value
    <p>The accounts list endpoint provides the list of accounts the user has at the <a data-link-type="dfn" href="#idp" id="ref-for-idp⑦">IDP</a>.</p>
    <p>The accounts list endpoint is fetched (a) <strong>with</strong> any cookies and (b) <strong>with</strong> a special <a href="#Sec-FedCM-CSR">§ 6.6 Sec-FedCM-CSR</a> header.</p>
    <p>For example:</p>
-   <div class="example" id="example-b9c74a47">
-    <a class="self-link" href="#example-b9c74a47"></a> 
-<pre class="language-http highlight">GET /accounts_list.php HTTPS/1.1
-Host: idp.example
-Accept: application/json
-Cookie: 0x23223
-Sec-FedCM-CSRF: random_value
+   <div class="example" id="example-cd9c559d">
+    <a class="self-link" href="#example-cd9c559d"></a> 
+<pre class="language-http highlight"><c- nf>GET</c-> <c- nn>/accounts_list.php</c-> <c- kr>HTTP</c-><c- o>/</c-><c- m>1.1</c->
+<c- e>Host</c-><c- o>:</c-> <c- l>idp.example</c->
+<c- e>Accept</c-><c- o>:</c-> <c- l>application/json</c->
+<c- e>Cookie</c-><c- o>:</c-> <c- l>0x23223</c->
+<c- e>Sec-FedCM-CSRF</c-><c- o>:</c-> <c- l>random_value</c->
 </pre>
    </div>
    <p>The response is expected to have the following properties:</p>
@@ -1192,12 +1202,12 @@ Sec-FedCM-CSRF: random_value
    <p>The client medata endpoint is fetched (a) <strong>without</strong> cookies and (b) <strong>with</strong> a special <a href="#Sec-FedCM-CSR">§ 6.6 Sec-FedCM-CSR</a> header.</p>
    <p>The user agent also passes the <strong>client_id</strong>.</p>
    <p>For example:</p>
-   <div class="example" id="example-1e90928d">
-    <a class="self-link" href="#example-1e90928d"></a> 
-<pre class="language-http highlight">GET /client_medata.php?client_id=1234 HTTPS/1.1
-Host: idp.example
-Accept: application/json
-Sec-FedCM-CSRF: random_value
+   <div class="example" id="example-dd2ba4fa">
+    <a class="self-link" href="#example-dd2ba4fa"></a> 
+<pre class="language-http highlight"><c- nf>GET</c-> <c- nn>/client_medata.php?client_id=1234</c-> <c- kr>HTTP</c-><c- o>/</c-><c- m>1.1</c->
+<c- e>Host</c-><c- o>:</c-> <c- l>idp.example</c->
+<c- e>Accept</c-><c- o>:</c-> <c- l>application/json</c->
+<c- e>Sec-FedCM-CSRF</c-><c- o>:</c-> <c- l>random_value</c->
 </pre>
    </div>
    <p>The file is parsed expecting the following properties:</p>
@@ -1240,21 +1250,21 @@ Sec-FedCM-CSRF: random_value
      <p>A random number of the choice of the <a data-link-type="dfn" href="#rp" id="ref-for-rp⑧">RP</a></p>
    </dl>
    <p>For example:</p>
-   <div class="example" id="example-00f580cd">
-    <a class="self-link" href="#example-00f580cd"></a> 
-<pre class="language-http highlight">POST /webid_token_endpoint HTTPS/1.1
-Host: idp.example
-Referrer: rp.example
-Content-Type: application/json
-Cookie: 0x23223
-Sec-FedCM-CSRF: random_value
+   <div class="example" id="example-e189e35c">
+    <a class="self-link" href="#example-e189e35c"></a> 
+<pre class="language-http highlight"><c- nf>POST</c-> <c- nn>/webid_token_endpoint</c-> <c- kr>HTTP</c-><c- o>/</c-><c- m>1.1</c->
+<c- e>Host</c-><c- o>:</c-> <c- l>idp.example</c->
+<c- e>Referer</c-><c- o>:</c-> <c- l>rp.example</c->
+<c- e>Content-Type</c-><c- o>:</c-> <c- l>application/json</c->
+<c- e>Cookie</c-><c- o>:</c-> <c- l>0x23223</c->
+<c- e>Sec-FedCM-CSRF</c-><c- o>:</c-> <c- l>random_value</c->
 {
-  "account_id": "123",
-  "request": {
-    "client_id": "client1234",
-    "nonce": "Ct60bD" 
-  }
-}
+  <c- f>"account_id"</c-><c- p>:</c-> <c- u>"123"</c-><c- p>,</c->
+  <c- f>"request"</c-><c- p>:</c-> <c- p>{</c->
+    <c- f>"client_id"</c-><c- p>:</c-> <c- u>"client1234"</c-><c- p>,</c->
+    <c- f>"nonce"</c-><c- p>:</c-> <c- u>"Ct60bD"</c-> 
+  <c- p>}</c->
+<c- p>}</c->
 </pre>
    </div>
    <p>The response is parsed as a JSON file expecting the following properties:</p>
@@ -1361,9 +1371,9 @@ the <a data-link-type="dfn" href="#rp" id="ref-for-rp①③">RP</a>.</p>
   <dfn class="idl-code" data-dfn-for="FederatedCredentialApprovedBy" data-dfn-type="enum-value" data-export id="dom-federatedcredentialapprovedby-user"><code><c- s>"user"</c-></code><a class="self-link" href="#dom-federatedcredentialapprovedby-user"></a></dfn>
 };
 
-[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext"><c- g>SecureContext</c-></a>]
+[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed" id="ref-for-Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->, <a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#SecureContext" id="ref-for-SecureContext"><c- g>SecureContext</c-></a>]
 <c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://w3c.github.io/webappsec-credential-management/#federatedcredential" id="ref-for-federatedcredential④"><c- g>FederatedCredential</c-></a> : <a data-link-type="idl-name" href="https://w3c.github.io/webappsec-credential-management/#credential" id="ref-for-credential"><c- n>Credential</c-></a> {
-  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString"><c- b>USVString</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="FederatedCredential" data-dfn-type="attribute" data-export data-readonly data-type="USVString" id="dom-federatedcredential-idtoken"><code><c- g>idToken</c-></code></dfn>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString" id="ref-for-idl-USVString"><c- b>USVString</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="FederatedCredential" data-dfn-type="attribute" data-export data-readonly data-type="USVString" id="dom-federatedcredential-idtoken"><code><c- g>idToken</c-></code></dfn>;
   <c- b>readonly</c-> <c- b>attribute</c-> <a data-link-type="idl-name" href="#enumdef-federatedcredentialapprovedby" id="ref-for-enumdef-federatedcredentialapprovedby"><c- n>FederatedCredentialApprovedBy</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="FederatedCredential" data-dfn-type="attribute" data-export data-readonly data-type="FederatedCredentialApprovedBy" id="dom-federatedcredential-approvedby"><code><c- g>approvedBy</c-></code></dfn>;
 };
 </pre>
@@ -1377,13 +1387,13 @@ the <a data-link-type="dfn" href="#rp" id="ref-for-rp①③">RP</a>.</p>
    </dl>
    <p>Second, it extends the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/webappsec-credential-management/#dictdef-federatedcredentialrequestoptions" id="ref-for-dictdef-federatedcredentialrequestoptions①">FederatedCredentialRequestOptions</a></code> by adding a list of <code class="idl"><a data-link-type="idl" href="#dictdef-federatedidentityprovider" id="ref-for-dictdef-federatedidentityprovider">FederatedIdentityProvider</a></code>s:</p>
 <pre class="idl highlight def"><c- b>partial</c-> <c- b>dictionary</c-> <a class="idl-code" data-link-type="dictionary" href="https://w3c.github.io/webappsec-credential-management/#dictdef-federatedcredentialrequestoptions" id="ref-for-dictdef-federatedcredentialrequestoptions②"><c- g>FederatedCredentialRequestOptions</c-></a> {
-  <a data-link-type="dfn" href="https://heycam.github.io/webidl/#idl-sequence" id="ref-for-idl-sequence"><c- b>sequence</c-></a>&lt;(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString" id="ref-for-idl-DOMString"><c- b>DOMString</c-></a> <c- b>or</c-> <a data-link-type="idl-name" href="#dictdef-federatedidentityprovider" id="ref-for-dictdef-federatedidentityprovider①"><c- n>FederatedIdentityProvider</c-></a>)> <dfn class="dfn-paneled idl-code" data-dfn-for="FederatedCredentialRequestOptions" data-dfn-type="dict-member" data-export data-type="sequence<(DOMString or FederatedIdentityProvider)> " id="dom-federatedcredentialrequestoptions-providers"><code><c- g>providers</c-></code></dfn>;
+  <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#idl-sequence" id="ref-for-idl-sequence"><c- b>sequence</c-></a>&lt;(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString" id="ref-for-idl-DOMString"><c- b>DOMString</c-></a> <c- b>or</c-> <a data-link-type="idl-name" href="#dictdef-federatedidentityprovider" id="ref-for-dictdef-federatedidentityprovider①"><c- n>FederatedIdentityProvider</c-></a>)> <dfn class="dfn-paneled idl-code" data-dfn-for="FederatedCredentialRequestOptions" data-dfn-type="dict-member" data-export data-type="sequence<(DOMString or FederatedIdentityProvider)> " id="dom-federatedcredentialrequestoptions-providers"><code><c- g>providers</c-></code></dfn>;
 };
 
 <c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-federatedidentityprovider"><code><c- g>FederatedIdentityProvider</c-></code></dfn> {
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString①"><c- b>USVString</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="FederatedIdentityProvider" data-dfn-type="dict-member" data-export data-type="USVString " id="dom-federatedidentityprovider-url"><code><c- g>url</c-></code></dfn>;
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString②"><c- b>USVString</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="FederatedIdentityProvider" data-dfn-type="dict-member" data-export data-type="USVString " id="dom-federatedidentityprovider-clientid"><code><c- g>clientId</c-></code></dfn>;
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString③"><c- b>USVString</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="FederatedIdentityProvider" data-dfn-type="dict-member" data-export data-type="USVString " id="dom-federatedidentityprovider-nonce"><code><c- g>nonce</c-></code></dfn>;
+  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString" id="ref-for-idl-USVString①"><c- b>USVString</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="FederatedIdentityProvider" data-dfn-type="dict-member" data-export data-type="USVString " id="dom-federatedidentityprovider-url"><code><c- g>url</c-></code></dfn>;
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString" id="ref-for-idl-USVString②"><c- b>USVString</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="FederatedIdentityProvider" data-dfn-type="dict-member" data-export data-type="USVString " id="dom-federatedidentityprovider-clientid"><code><c- g>clientId</c-></code></dfn>;
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString" id="ref-for-idl-USVString③"><c- b>USVString</c-></a> <dfn class="dfn-paneled idl-code" data-dfn-for="FederatedIdentityProvider" data-dfn-type="dict-member" data-export data-type="USVString " id="dom-federatedidentityprovider-nonce"><code><c- g>nonce</c-></code></dfn>;
 };
 </pre>
    <p>And finally, this specification overrides the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/webappsec-credential-management/#federatedcredential" id="ref-for-federatedcredential⑤">FederatedCredential</a></code>'s <code><dfn class="idl-code" data-dfn-for="FederatedCredential" data-dfn-type="method" data-export id="dom-federatedcredential-discoverfromexternalsource-origin-options-sameoriginwithancestors-slot"><code>[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)</code><a class="self-link" href="#dom-federatedcredential-discoverfromexternalsource-origin-options-sameoriginwithancestors-slot"></a></dfn></code> Method.</p>
@@ -1404,7 +1414,7 @@ calling <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/we
    <p>When this method is invoked, the user agent MUST execute the following algorithm:</p>
    <ol>
     <li data-md>
-     <p>If <var>sameOriginWithAncestors</var> is <code>false</code>, return a "<code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#notallowederror" id="ref-for-notallowederror">NotAllowedError</a></code>" <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException">DOMException</a></code>.</p>
+     <p>If <var>sameOriginWithAncestors</var> is <code>false</code>, return a "<code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#notallowederror" id="ref-for-notallowederror">NotAllowedError</a></code>" <code class="idl"><a data-link-type="idl" href="https://webidl.spec.whatwg.org/#idl-DOMException" id="ref-for-idl-DOMException">DOMException</a></code>.</p>
      <p class="note" role="note"><span>Note:</span> This restriction aims to address the concern raised in <a data-link-type="biblio" href="https://w3c.github.io/webappsec-credential-management/#security-origin-confusion"><cite>Security Origin Confusion</cite></a>.</p>
     <li data-md>
      <p class="assertion">Assert: <var>options</var>["<code class="idl"><a data-link-type="idl" href="https://w3c.github.io/webappsec-credential-management/#dom-credentialrequestoptions-federated" id="ref-for-dom-credentialrequestoptions-federated①">federated</a></code>"]["<code class="idl"><a data-link-type="idl" href="#dom-federatedcredentialrequestoptions-providers" id="ref-for-dom-federatedcredentialrequestoptions-providers">providers</a></code>"] <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-exists" id="ref-for-map-exists">exists</a>.</p>
@@ -1581,9 +1591,9 @@ instead of a <a href="#use-cases-sign-in">§ 2.2 Sign-in</a> flow.</p>
 </pre>
    </div>
    <p>This specification extends the <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/webappsec-credential-management/#federatedcredential" id="ref-for-federatedcredential⑧">FederatedCredential</a></code> interface with an extra static method:</p>
-<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①"><c- g>Exposed</c-></a>=<c- n>Window</c->, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext①"><c- g>SecureContext</c-></a>]
+<pre class="idl highlight def">[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed" id="ref-for-Exposed①"><c- g>Exposed</c-></a>=<c- n>Window</c->, <a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#SecureContext" id="ref-for-SecureContext①"><c- g>SecureContext</c-></a>]
 <c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://w3c.github.io/webappsec-credential-management/#federatedcredential" id="ref-for-federatedcredential⑨"><c- g>FederatedCredential</c-></a> : <a data-link-type="idl-name" href="https://w3c.github.io/webappsec-credential-management/#credential" id="ref-for-credential①"><c- n>Credential</c-></a> {
-  <c- b>static</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-promise" id="ref-for-idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name"><c- n>void</c-></a>> <dfn class="idl-code" data-dfn-for="FederatedCredential" data-dfn-type="method" data-export data-lt="revoke(accountId)" id="dom-federatedcredential-revoke"><code><c- g>revoke</c-></code><a class="self-link" href="#dom-federatedcredential-revoke"></a></dfn>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString④"><c- b>USVString</c-></a> <dfn class="idl-code" data-dfn-for="FederatedCredential/revoke(accountId)" data-dfn-type="argument" data-export id="dom-federatedcredential-revoke-accountid-accountid"><code><c- g>accountId</c-></code><a class="self-link" href="#dom-federatedcredential-revoke-accountid-accountid"></a></dfn>);
+  <c- b>static</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name"><c- n>void</c-></a>> <dfn class="idl-code" data-dfn-for="FederatedCredential" data-dfn-type="method" data-export data-lt="revoke(accountId)" id="dom-federatedcredential-revoke"><code><c- g>revoke</c-></code><a class="self-link" href="#dom-federatedcredential-revoke"></a></dfn>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString" id="ref-for-idl-USVString④"><c- b>USVString</c-></a> <dfn class="idl-code" data-dfn-for="FederatedCredential/revoke(accountId)" data-dfn-type="argument" data-export id="dom-federatedcredential-revoke-accountid-accountid"><code><c- g>accountId</c-></code><a class="self-link" href="#dom-federatedcredential-revoke-accountid-accountid"></a></dfn>);
 };
 </pre>
    <p class="note" role="note"><span>Note:</span> go over the revocation API.</p>
@@ -1629,13 +1639,13 @@ through an <a href="#use-cases-explicit-sign-in">§ 2.2.2 Explicit Sign-in</a>
    </div>
    <p><a data-link-type="dfn" href="#idp" id="ref-for-idp①⑧">IDP</a>s can call <code><a data-link-type="idl">FederatedCredential.logout(...)</a></code> to log the user out of the <a data-link-type="dfn" href="#rp" id="ref-for-rp②③">RP</a>s they are signed into.</p>
 <pre class="idl highlight def"><c- b>dictionary</c-> <dfn class="dfn-paneled idl-code" data-dfn-type="dictionary" data-export id="dictdef-webidlogoutrequest"><code><c- g>WebIdLogoutRequest</c-></code></dfn> {
-    <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑤"><c- b>USVString</c-></a> <dfn class="idl-code" data-dfn-for="WebIdLogoutRequest" data-dfn-type="dict-member" data-export data-type="USVString " id="dom-webidlogoutrequest-endpoint"><code><c- g>endpoint</c-></code><a class="self-link" href="#dom-webidlogoutrequest-endpoint"></a></dfn>;
-    <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString" id="ref-for-idl-USVString⑥"><c- b>USVString</c-></a> <dfn class="idl-code" data-dfn-for="WebIdLogoutRequest" data-dfn-type="dict-member" data-export data-type="USVString " id="dom-webidlogoutrequest-accountid"><code><c- g>accountId</c-></code><a class="self-link" href="#dom-webidlogoutrequest-accountid"></a></dfn>;
+    <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString" id="ref-for-idl-USVString⑤"><c- b>USVString</c-></a> <dfn class="idl-code" data-dfn-for="WebIdLogoutRequest" data-dfn-type="dict-member" data-export data-type="USVString " id="dom-webidlogoutrequest-endpoint"><code><c- g>endpoint</c-></code><a class="self-link" href="#dom-webidlogoutrequest-endpoint"></a></dfn>;
+    <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString" id="ref-for-idl-USVString⑥"><c- b>USVString</c-></a> <dfn class="idl-code" data-dfn-for="WebIdLogoutRequest" data-dfn-type="dict-member" data-export data-type="USVString " id="dom-webidlogoutrequest-accountid"><code><c- g>accountId</c-></code><a class="self-link" href="#dom-webidlogoutrequest-accountid"></a></dfn>;
 };
 
-[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed②"><c- g>Exposed</c-></a>=<c- n>Window</c->, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext②"><c- g>SecureContext</c-></a>]
+[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed" id="ref-for-Exposed②"><c- g>Exposed</c-></a>=<c- n>Window</c->, <a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#SecureContext" id="ref-for-SecureContext②"><c- g>SecureContext</c-></a>]
 <c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://w3c.github.io/webappsec-credential-management/#federatedcredential" id="ref-for-federatedcredential①⓪"><c- g>FederatedCredential</c-></a> : <a data-link-type="idl-name" href="https://w3c.github.io/webappsec-credential-management/#credential" id="ref-for-credential②"><c- n>Credential</c-></a> {
-  <c- b>static</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-promise" id="ref-for-idl-promise①"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name"><c- n>void</c-></a>> <dfn class="idl-code" data-dfn-for="FederatedCredential" data-dfn-type="method" data-export data-lt="logout(logout_requests)|logout()" id="dom-federatedcredential-logout"><code><c- g>logout</c-></code><a class="self-link" href="#dom-federatedcredential-logout"></a></dfn>(<c- b>optional</c-> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#idl-sequence" id="ref-for-idl-sequence①"><c- b>sequence</c-></a>&lt;<a data-link-type="idl-name" href="#dictdef-webidlogoutrequest" id="ref-for-dictdef-webidlogoutrequest"><c- n>WebIdLogoutRequest</c-></a>> <dfn class="idl-code" data-dfn-for="FederatedCredential/logout(logout_requests), FederatedCredential/logout()" data-dfn-type="argument" data-export id="dom-federatedcredential-logout-logout_requests-logout_requests"><code><c- g>logout_requests</c-></code><a class="self-link" href="#dom-federatedcredential-logout-logout_requests-logout_requests"></a></dfn> = []);
+  <c- b>static</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise" id="ref-for-idl-promise①"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name"><c- n>void</c-></a>> <dfn class="idl-code" data-dfn-for="FederatedCredential" data-dfn-type="method" data-export data-lt="logout(logout_requests)|logout()" id="dom-federatedcredential-logout"><code><c- g>logout</c-></code><a class="self-link" href="#dom-federatedcredential-logout"></a></dfn>(<c- b>optional</c-> <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#idl-sequence" id="ref-for-idl-sequence①"><c- b>sequence</c-></a>&lt;<a data-link-type="idl-name" href="#dictdef-webidlogoutrequest" id="ref-for-dictdef-webidlogoutrequest"><c- n>WebIdLogoutRequest</c-></a>> <dfn class="idl-code" data-dfn-for="FederatedCredential/logout(logout_requests), FederatedCredential/logout()" data-dfn-type="argument" data-export id="dom-federatedcredential-logout-logout_requests-logout_requests"><code><c- g>logout_requests</c-></code><a class="self-link" href="#dom-federatedcredential-logout-logout_requests-logout_requests"></a></dfn> = []);
 };
 </pre>
    <p class="note" role="note"><span>Note:</span> go over how this is implemented.</p>
@@ -2085,8 +2095,8 @@ global identifiers are exchanged a more conservative user experience.</p>
     <li data-md>
      <p><a href="#cross-site-correlation">§ 10.1.3.1.1 Cross-Site Correlation</a></p>
    </ul>
-   <p>Currently, IDPs require that an RP pre-registers and agrees to specific terms before the IDP will issue an ID token to them. T
-his conflicts with <a href="#self-presentation">the previous mitigation</a>, but can provide a measure of RP accountability.</p>
+   <p>Currently, IDPs require that an RP pre-registers and agrees to specific terms before the IDP will issue an ID token to them.
+This conflicts with <a href="#self-presentation">the previous mitigation</a>, but can provide a measure of RP accountability.</p>
    <h4 class="heading settled" data-level="10.2.6" id="2fa"><span class="secno">10.2.6. </span><span class="content">2FA</span><a class="self-link" href="#2fa"></a></h4>
    <p>Mitigates:</p>
    <ul>
@@ -2345,19 +2355,19 @@ his conflicts with <a href="#self-presentation">the previous mitigation</a>, but
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-DOMException">
-   <a href="https://heycam.github.io/webidl/#idl-DOMException">https://heycam.github.io/webidl/#idl-DOMException</a><b>Referenced in:</b>
+   <a href="https://webidl.spec.whatwg.org/#idl-DOMException">https://webidl.spec.whatwg.org/#idl-DOMException</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMException">8.2.1. RP Sign-in API</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-DOMString">
-   <a href="https://heycam.github.io/webidl/#idl-DOMString">https://heycam.github.io/webidl/#idl-DOMString</a><b>Referenced in:</b>
+   <a href="https://webidl.spec.whatwg.org/#idl-DOMString">https://webidl.spec.whatwg.org/#idl-DOMString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-DOMString">8.2.1. RP Sign-in API</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-Exposed">
-   <a href="https://heycam.github.io/webidl/#Exposed">https://heycam.github.io/webidl/#Exposed</a><b>Referenced in:</b>
+   <a href="https://webidl.spec.whatwg.org/#Exposed">https://webidl.spec.whatwg.org/#Exposed</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-Exposed">8.2.1. RP Sign-in API</a>
     <li><a href="#ref-for-Exposed①">8.3. The Revocation API</a>
@@ -2365,20 +2375,20 @@ his conflicts with <a href="#self-presentation">the previous mitigation</a>, but
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-notallowederror">
-   <a href="https://heycam.github.io/webidl/#notallowederror">https://heycam.github.io/webidl/#notallowederror</a><b>Referenced in:</b>
+   <a href="https://webidl.spec.whatwg.org/#notallowederror">https://webidl.spec.whatwg.org/#notallowederror</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-notallowederror">8.2.1. RP Sign-in API</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-promise">
-   <a href="https://heycam.github.io/webidl/#idl-promise">https://heycam.github.io/webidl/#idl-promise</a><b>Referenced in:</b>
+   <a href="https://webidl.spec.whatwg.org/#idl-promise">https://webidl.spec.whatwg.org/#idl-promise</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-promise">8.3. The Revocation API</a>
     <li><a href="#ref-for-idl-promise①">8.4.2. IDP Sign-out</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-SecureContext">
-   <a href="https://heycam.github.io/webidl/#SecureContext">https://heycam.github.io/webidl/#SecureContext</a><b>Referenced in:</b>
+   <a href="https://webidl.spec.whatwg.org/#SecureContext">https://webidl.spec.whatwg.org/#SecureContext</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-SecureContext">8.2.1. RP Sign-in API</a>
     <li><a href="#ref-for-SecureContext①">8.3. The Revocation API</a>
@@ -2386,7 +2396,7 @@ his conflicts with <a href="#self-presentation">the previous mitigation</a>, but
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-USVString">
-   <a href="https://heycam.github.io/webidl/#idl-USVString">https://heycam.github.io/webidl/#idl-USVString</a><b>Referenced in:</b>
+   <a href="https://webidl.spec.whatwg.org/#idl-USVString">https://webidl.spec.whatwg.org/#idl-USVString</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-USVString">8.2.1. RP Sign-in API</a> <a href="#ref-for-idl-USVString①">(2)</a> <a href="#ref-for-idl-USVString②">(3)</a> <a href="#ref-for-idl-USVString③">(4)</a>
     <li><a href="#ref-for-idl-USVString④">8.3. The Revocation API</a>
@@ -2394,7 +2404,7 @@ his conflicts with <a href="#self-presentation">the previous mitigation</a>, but
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-idl-sequence">
-   <a href="https://heycam.github.io/webidl/#idl-sequence">https://heycam.github.io/webidl/#idl-sequence</a><b>Referenced in:</b>
+   <a href="https://webidl.spec.whatwg.org/#idl-sequence">https://webidl.spec.whatwg.org/#idl-sequence</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-idl-sequence">8.2.1. RP Sign-in API</a>
     <li><a href="#ref-for-idl-sequence①">8.4.2. IDP Sign-out</a>
@@ -2444,7 +2454,7 @@ his conflicts with <a href="#self-presentation">the previous mitigation</a>, but
      <li><span class="dfn-paneled" id="term-for-host-registrable-domain">registrable domain</span>
     </ul>
    <li>
-    <a data-link-type="biblio">[WebIDL]</a> defines the following terms:
+    <a data-link-type="biblio">[WEBIDL]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-idl-DOMException">DOMException</span>
      <li><span class="dfn-paneled" id="term-for-idl-DOMString">DOMString</span>
@@ -2471,8 +2481,8 @@ his conflicts with <a href="#self-presentation">the previous mitigation</a>, but
    <dd>S. Bradner. <a href="https://datatracker.ietf.org/doc/html/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. March 1997. Best Current Practice. URL: <a href="https://datatracker.ietf.org/doc/html/rfc2119">https://datatracker.ietf.org/doc/html/rfc2119</a>
    <dt id="biblio-url">[URL]
    <dd>Anne van Kesteren. <a href="https://url.spec.whatwg.org/"><cite>URL Standard</cite></a>. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
-   <dt id="biblio-webidl">[WebIDL]
-   <dd>Boris Zbarsky. <a href="https://heycam.github.io/webidl/"><cite>Web IDL</cite></a>. 15 December 2016. ED. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
+   <dt id="biblio-webidl">[WEBIDL]
+   <dd>Edgar Chen; Timothy Gu. <a href="https://webidl.spec.whatwg.org/"><cite>Web IDL Standard</cite></a>. Living Standard. URL: <a href="https://webidl.spec.whatwg.org/">https://webidl.spec.whatwg.org/</a>
   </dl>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
@@ -2515,35 +2525,35 @@ his conflicts with <a href="#self-presentation">the previous mitigation</a>, but
   <a href="#dom-federatedcredentialapprovedby-user"><code><c- s>"user"</c-></code></a>
 };
 
-[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext"><c- g>SecureContext</c-></a>]
+[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->, <a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#SecureContext"><c- g>SecureContext</c-></a>]
 <c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://w3c.github.io/webappsec-credential-management/#federatedcredential"><c- g>FederatedCredential</c-></a> : <a data-link-type="idl-name" href="https://w3c.github.io/webappsec-credential-management/#credential"><c- n>Credential</c-></a> {
-  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><c- b>USVString</c-></a> <a data-readonly data-type="USVString" href="#dom-federatedcredential-idtoken"><code><c- g>idToken</c-></code></a>;
+  <c- b>readonly</c-> <c- b>attribute</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString"><c- b>USVString</c-></a> <a data-readonly data-type="USVString" href="#dom-federatedcredential-idtoken"><code><c- g>idToken</c-></code></a>;
   <c- b>readonly</c-> <c- b>attribute</c-> <a data-link-type="idl-name" href="#enumdef-federatedcredentialapprovedby"><c- n>FederatedCredentialApprovedBy</c-></a> <a data-readonly data-type="FederatedCredentialApprovedBy" href="#dom-federatedcredential-approvedby"><code><c- g>approvedBy</c-></code></a>;
 };
 
 <c- b>partial</c-> <c- b>dictionary</c-> <a class="idl-code" data-link-type="dictionary" href="https://w3c.github.io/webappsec-credential-management/#dictdef-federatedcredentialrequestoptions"><c- g>FederatedCredentialRequestOptions</c-></a> {
-  <a data-link-type="dfn" href="https://heycam.github.io/webidl/#idl-sequence"><c- b>sequence</c-></a>&lt;(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-DOMString"><c- b>DOMString</c-></a> <c- b>or</c-> <a data-link-type="idl-name" href="#dictdef-federatedidentityprovider"><c- n>FederatedIdentityProvider</c-></a>)> <a data-type="sequence<(DOMString or FederatedIdentityProvider)> " href="#dom-federatedcredentialrequestoptions-providers"><code><c- g>providers</c-></code></a>;
+  <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#idl-sequence"><c- b>sequence</c-></a>&lt;(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-DOMString"><c- b>DOMString</c-></a> <c- b>or</c-> <a data-link-type="idl-name" href="#dictdef-federatedidentityprovider"><c- n>FederatedIdentityProvider</c-></a>)> <a data-type="sequence<(DOMString or FederatedIdentityProvider)> " href="#dom-federatedcredentialrequestoptions-providers"><code><c- g>providers</c-></code></a>;
 };
 
 <c- b>dictionary</c-> <a href="#dictdef-federatedidentityprovider"><code><c- g>FederatedIdentityProvider</c-></code></a> {
-  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><c- b>USVString</c-></a> <a data-type="USVString " href="#dom-federatedidentityprovider-url"><code><c- g>url</c-></code></a>;
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><c- b>USVString</c-></a> <a data-type="USVString " href="#dom-federatedidentityprovider-clientid"><code><c- g>clientId</c-></code></a>;
-  <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><c- b>USVString</c-></a> <a data-type="USVString " href="#dom-federatedidentityprovider-nonce"><code><c- g>nonce</c-></code></a>;
+  <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString"><c- b>USVString</c-></a> <a data-type="USVString " href="#dom-federatedidentityprovider-url"><code><c- g>url</c-></code></a>;
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString"><c- b>USVString</c-></a> <a data-type="USVString " href="#dom-federatedidentityprovider-clientid"><code><c- g>clientId</c-></code></a>;
+  <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString"><c- b>USVString</c-></a> <a data-type="USVString " href="#dom-federatedidentityprovider-nonce"><code><c- g>nonce</c-></code></a>;
 };
 
-[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext"><c- g>SecureContext</c-></a>]
+[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->, <a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#SecureContext"><c- g>SecureContext</c-></a>]
 <c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://w3c.github.io/webappsec-credential-management/#federatedcredential"><c- g>FederatedCredential</c-></a> : <a data-link-type="idl-name" href="https://w3c.github.io/webappsec-credential-management/#credential"><c- n>Credential</c-></a> {
-  <c- b>static</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name"><c- n>void</c-></a>> <a href="#dom-federatedcredential-revoke"><code><c- g>revoke</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><c- b>USVString</c-></a> <a href="#dom-federatedcredential-revoke-accountid-accountid"><code><c- g>accountId</c-></code></a>);
+  <c- b>static</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name"><c- n>void</c-></a>> <a href="#dom-federatedcredential-revoke"><code><c- g>revoke</c-></code></a>(<a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString"><c- b>USVString</c-></a> <a href="#dom-federatedcredential-revoke-accountid-accountid"><code><c- g>accountId</c-></code></a>);
 };
 
 <c- b>dictionary</c-> <a href="#dictdef-webidlogoutrequest"><code><c- g>WebIdLogoutRequest</c-></code></a> {
-    <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><c- b>USVString</c-></a> <a data-type="USVString " href="#dom-webidlogoutrequest-endpoint"><code><c- g>endpoint</c-></code></a>;
-    <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-USVString"><c- b>USVString</c-></a> <a data-type="USVString " href="#dom-webidlogoutrequest-accountid"><code><c- g>accountId</c-></code></a>;
+    <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString"><c- b>USVString</c-></a> <a data-type="USVString " href="#dom-webidlogoutrequest-endpoint"><code><c- g>endpoint</c-></code></a>;
+    <c- b>required</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-USVString"><c- b>USVString</c-></a> <a data-type="USVString " href="#dom-webidlogoutrequest-accountid"><code><c- g>accountId</c-></code></a>;
 };
 
-[<a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->, <a class="idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext"><c- g>SecureContext</c-></a>]
+[<a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#Exposed"><c- g>Exposed</c-></a>=<c- n>Window</c->, <a class="idl-code" data-link-type="extended-attribute" href="https://webidl.spec.whatwg.org/#SecureContext"><c- g>SecureContext</c-></a>]
 <c- b>partial</c-> <c- b>interface</c-> <a class="idl-code" data-link-type="interface" href="https://w3c.github.io/webappsec-credential-management/#federatedcredential"><c- g>FederatedCredential</c-></a> : <a data-link-type="idl-name" href="https://w3c.github.io/webappsec-credential-management/#credential"><c- n>Credential</c-></a> {
-  <c- b>static</c-> <a class="idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name"><c- n>void</c-></a>> <a href="#dom-federatedcredential-logout"><code><c- g>logout</c-></code></a>(<c- b>optional</c-> <a data-link-type="dfn" href="https://heycam.github.io/webidl/#idl-sequence"><c- b>sequence</c-></a>&lt;<a data-link-type="idl-name" href="#dictdef-webidlogoutrequest"><c- n>WebIdLogoutRequest</c-></a>> <a href="#dom-federatedcredential-logout-logout_requests-logout_requests"><code><c- g>logout_requests</c-></code></a> = []);
+  <c- b>static</c-> <a class="idl-code" data-link-type="interface" href="https://webidl.spec.whatwg.org/#idl-promise"><c- b>Promise</c-></a>&lt;<a data-link-type="idl-name"><c- n>void</c-></a>> <a href="#dom-federatedcredential-logout"><code><c- g>logout</c-></code></a>(<c- b>optional</c-> <a data-link-type="dfn" href="https://webidl.spec.whatwg.org/#idl-sequence"><c- b>sequence</c-></a>&lt;<a data-link-type="idl-name" href="#dictdef-webidlogoutrequest"><c- n>WebIdLogoutRequest</c-></a>> <a href="#dom-federatedcredential-logout-logout_requests-logout_requests"><code><c- g>logout_requests</c-></code></a> = []);
 };
 
 </pre>


### PR DESCRIPTION
HTTP requests use HTTP/1.1, not HTTPS/1.1, even if done over a secure
connection.
Also, the header is spelled Referer, even though that is a misspelling.

And this patch also fixes a poorly-placed linebreak in the middle of a word.