### PR TITLE
Add script to generate IDL file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,0 @@
-*~
-.bundle/
-.jekyll-metadata
-Gemfile.lock
-_site/
-vendor/

--- a/docs/fedcm.idl
+++ b/docs/fedcm.idl
@@ -1,0 +1,51 @@
+// Copyright (C) [2021] World Wide Web Consortium,
+// (Massachusetts Institute of Technology, European Research Consortium for
+// Informatics and Mathematics, Keio University, Beihang).
+// All Rights Reserved.
+//
+// This work is distributed under the W3C (R) Software License [1] in the hope
+// that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+// warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+// [1] http://www.w3.org/Consortium/Legal/copyright-software
+
+//
+// **** This file is auto-generated. Do not edit. ****
+//
+
+enum FederatedCredentialApprovedBy {
+  "auto",
+  "user"
+};
+
+[Exposed=Window, SecureContext]
+partial interface FederatedCredential : Credential {
+  readonly attribute USVString idToken;
+  readonly attribute FederatedCredentialApprovedBy approvedBy;
+};
+
+partial dictionary FederatedCredentialRequestOptions {
+  sequence<(DOMString or FederatedIdentityProvider)> providers;
+};
+
+dictionary FederatedIdentityProvider {
+  required USVString url;
+  USVString clientId;
+  USVString nonce;
+};
+
+[Exposed=Window, SecureContext]
+partial interface FederatedCredential : Credential {
+  static Promise<void> revoke(USVString accountId);
+};
+
+dictionary WebIdLogoutRequest {
+    required USVString endpoint;
+    required USVString accountId;
+};
+
+[Exposed=Window, SecureContext]
+partial interface FederatedCredential : Credential {
+  static Promise<void> logout(optional sequence<WebIdLogoutRequest> logout_requests = []);
+};
+

--- a/spec/Makefile
+++ b/spec/Makefile
@@ -1,5 +1,20 @@
-all: ../docs/index.html
+DEST=../docs
 
-../docs/index.html: Makefile index.bs
+.PHONY: all spec idl clean
+
+all: spec idl
+
+spec: $(DEST)/index.html
+
+idl: $(DEST)/fedcm.idl
+
+$(DEST)/fedcm.idl: index.bs
+	./extract_idl.rb $(DEST)/fedcm.idl
+
+$(DEST)/index.html: index.bs
 	bikeshed --die-on=fatal --allow-nonlocal-files spec index.bs
-	mv index.html ../docs
+	mv index.html $(DEST)
+
+clean:
+	rm $(DEST)/index.html
+	rm $(DEST)/fedcm.idl

--- a/spec/extract_idl.rb
+++ b/spec/extract_idl.rb
@@ -1,0 +1,47 @@
+#!/usr/bin/env ruby
+
+require 'date'
+
+if ARGV.length < 1
+  puts "Filename required"
+  exit 2
+end
+
+outfile = ARGV[0]
+
+YEAR=DateTime.now.year
+HEADER=<<HERE
+// Copyright (C) [#{YEAR}] World Wide Web Consortium,
+// (Massachusetts Institute of Technology, European Research Consortium for
+// Informatics and Mathematics, Keio University, Beihang).
+// All Rights Reserved.
+//
+// This work is distributed under the W3C (R) Software License [1] in the hope
+// that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+// warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+//
+// [1] http://www.w3.org/Consortium/Legal/copyright-software
+
+//
+// **** This file is auto-generated. Do not edit. ****
+//
+
+HERE
+
+File.open(outfile, 'w') do |f|
+  f.puts HEADER
+
+  in_idl = false
+  File.open('index.bs').read.split("\n").each do |l|
+    if in_idl
+      if l =~ /<\/xmp>/
+        f.puts
+        in_idl = false
+      else
+        f.puts l
+      end
+    elsif l =~ /xmp class="?idl/
+      in_idl = true
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a simple script to extract the IDL content from the
BikeShed source and generate an IDL file for FedCM.