### PR TITLE
Make revoke() a non-static method

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -294,7 +294,11 @@ which the [=RP=] can use to authenticate the user.
     }
 
     async function revoke() {
-      await FederatedCredential.revoke(user.id, identityProvider);
+      await new FederatedCredential({
+          id: user.id,
+          provider: identityProvider.url,
+          client_id: identityProvider.clientId,
+        }).revoke();
     }
     </script>
   </body>
@@ -1025,17 +1029,23 @@ instead of a [[#use-cases-sign-in]] flow.
 <div class=example>
 ```js
 async function revoke(accountId, identityProvider) {
-  return await FederatedCredential.revoke(accountId, identityProvider);
+  return await new FederatedCredential({
+    id: accountId,
+    provider: identityProvider.url,
+    client_id: identityProvider.clientId,
+  }).revoke();
+
+);
 }
 ```
 </div>
 
-This specification extends the {{FederatedCredential}} interface with an extra static method:
+This specification extends the {{FederatedCredential}} interface with an extra method:
 
 <xmp class=idl>
 [Exposed=Window, SecureContext]
 partial interface FederatedCredential {
-  static Promise<undefined> revoke(USVString accountId, FederatedIdentityProvider provider);
+  Promise<undefined> revoke();
 };
 </xmp>
 


### PR DESCRIPTION
Fixes: #121


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cbiesinger/WebID/pull/139.html" title="Last updated on Nov 3, 2021, 10:08 PM UTC (b6204db)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/FedCM/139/2ae2dc6...cbiesinger:b6204db.html" title="Last updated on Nov 3, 2021, 10:08 PM UTC (b6204db)">Diff</a>