### PR TITLE
Update index.bs

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -945,6 +945,8 @@ When this method is invoked, the user agent MUST execute the following algorithm
     1. Let |wellknown| be the result of running the [=fetch the well-known=] algorithm with the |provider|.
 
     1. Let |accounts list| be the result of running the [=fetch the accounts list=] algorithm.
+    
+    1. Let |client id metadata| be the result of running the [=fetch the client id metadata=] algorithm.
 
     1. Let |account| be the result of running the [=select an account=] from the |accounts list| algorithm.
 


### PR DESCRIPTION
Adding "fetch the client id metadata" to the "RP Sign-in API" steps.

I *think* that running the "fetch the accounts list" algorithm prior to running the "fetch the client id metadata" algorithm makes fingerprinting (slightly?) harder. Specifically, I think that it makes fingerprinting without showing any FedCM browser UI at all harder.

If the "fetch the accounts list" HTTP request returns invalid data, the FedCM prompt is not shown.
If the "client id metadata" HTTP request returns invalid data, the FedCM prompt can still be shown.

If:
1) fetching the "client id metadata" algorithm is run prior to the "fetch the accounts list"
2) malicious site pretending to be an IDP returns empty account list

FedCM does not show any browser UI
The malicious site pretending to be an IDP receives both the "fetch the accounts list" HTTP request and the "client id metadata" HTTP request and can try to statistically join the two requests.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/pkotwicz/FedCM/pull/156.html" title="Last updated on Nov 24, 2021, 1:11 AM UTC (d72a31a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/FedCM/156/b100996...pkotwicz:d72a31a.html" title="Last updated on Nov 24, 2021, 1:11 AM UTC (d72a31a)">Diff</a>