### PR TITLE
Update the abstract

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -16,7 +16,7 @@ Text Macro: TRUE <code>true</code>
 Text Macro: RP Relying Party
 Text Macro: IDP Identity Provider
 
-Abstract: This specification provides an API enabling a website to request a users federated credentials from a user agent, and to help the user agent store the users federated credentials for future use.
+Abstract: A Web Platform API that allows users to login to websites with their federated accounts in a privacy preserving manner.
 
 Test Suite: https://github.com/web-platform-tests/wpt/blob/master/credential-management/webid.https.html
 </pre>
@@ -93,13 +93,13 @@ The API provides the primitives needed to support federated identity when/where
 it depends on third-party cookies, from sign-in to sign-out and revocation.
 
 In order to provide the federated identity primitives without the use of
-third-party cookies the API places the User Agent as a mediator between [=RPs=]
-and [=IDPs=]. This mediation requires user consent before permitting
+third-party cookies the API places the [=User Agent=] as a mediator between
+[=RPs=] and [=IDPs=]. This mediation requires user consent before permitting
 the [=RPs=] and [=IDPs=] to know about their connection to the user.
 
-The specification leans heavily on changes in the User Agent and [=IDP=] and
-minimally on the [=RP=]. The FedCM API provides a way to authenticate, fetch
-tokens, revoke the provided tokens, and allow for front-channel logout.
+The specification leans heavily on changes in the [=User Agent=] and [=IDP=]
+and minimally on the [=RP=]. The FedCM API provides a way to authenticate,
+fetch tokens, revoke the provided tokens, and allow for front-channel logout.
 
 <!-- ============================================================ -->
 ## Use Cases ## {#use-cases}


### PR DESCRIPTION
Small abstract change. I think I liked the two-liner that we used for the Ready for Trial and I think it works best than what we currently have.

Otherwise, just small linkification changes in the introduction.