### PR TITLE
Move branding information to fedcm.json manifest

### DIFF
--- a/explainer/HOWTO.md
+++ b/explainer/HOWTO.md
@@ -119,7 +119,15 @@ containing four fields:
   "accounts_endpoint": "https://idp.example/fedcm/accounts_endpoint",
   "client_id_metadata_endpoint": "https://idp.example/fedcm/client_id_metadata_endpoint",
   "id_token_endpoint": "https://idp.example/fedcm/token_endpoint",
-  "revocation_endpoint": "https://idp.example/fedcm/revocation_endpoint"
+  "revocation_endpoint": "https://idp.example/fedcm/revocation_endpoint",
+  "branding": {
+    "background_color": "green",
+    "color": "#FFEEAA",
+    "icons": [{
+      "url": "https://idp.example/icon.ico",
+      "size": 10
+    }]
+  }
 }
 ```
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -553,7 +553,7 @@ The <dfn>Icon JSON</dfn> may have the following properties:
         [maskable](https://www.w3.org/TR/appmanifest/#icon-masks) specification.
     :   <dfn>size</dfn> (optional)
     ::  The size of the icon. The icon is assumed to be square and single resolution
-        (not a multi-resolution .ico). The size should be ommitted if the icon is in
+        (not a multi-resolution .ico). The size may be ommitted if the icon is in
         a vector graphic format (like SVG).
 </dl>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -524,16 +524,22 @@ The file is parsed expecting the following properties:
     ::  A set of [=Branding JSON=] options.
 </dl>
 
-The <dfn>Branding JSON</dfn> enables an [=IDP=] to express their branding preferences, which may be used by User Agents to customize the user agent consent prompt.
+The <dfn>Branding JSON</dfn> enables an [=IDP=] to express their branding
+preferences, which may be used by User Agents to customize the user agent
+consent prompt.
 
-Note: The branding preferences are deliberately designed to be high level / abstract (rather than opinionated about a specific UI structure), to enable different [=User Agents=] to offer different UI experiences and for them to evolve independently over time.
+Note: The branding preferences are deliberately designed to be high level
+/ abstract (rather than opinionated about a specific UI structure), to
+enable different [=User Agents=] to offer different UI experiences and
+for them to evolve independently over time.
 
 It may have the following properties:
 <dl dfn-type="argument" dfn-for="manifest_branding">
     :   <dfn>background_color</dfn> (optional)
-    ::  background [=color=] for [=IDP=]-branded widgets such as buttons.
+    ::  Background [=color=] for [=IDP=]-branded widgets such as buttons.
     :   <dfn>color</dfn> (optional)
-    ::  [=color=] for text on widgets with [=background_color=].
+    ::  [=color=] for text on [=IDP=] branded widgets using
+        [=background_color=].
     :   <dfn>icons</dfn> (optional)
     ::  A list of [=Icon JSON=] objects.
 </dl>
@@ -543,8 +549,8 @@ The <dfn>Icon JSON</dfn> may have the following properties:
 <dl dfn-type="argument" dfn-for="manifest_branding_icons">
     :   <dfn>url</dfn> (required)
     ::  The url pointing to the icon image.
-        The icon needs to comply with the [maskable](https://www.w3.org/TR/appmanifest/#icon-masks)
-        specification.
+        The icon needs to comply with the
+        [maskable](https://www.w3.org/TR/appmanifest/#icon-masks) specification.
     :   <dfn>size</dfn> (optional)
     ::  The size of the icon. The icon is assumed to be square and single resolution
         (not a multi-resolution .ico). The size should be ommitted if the icon is in

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -553,7 +553,7 @@ The <dfn>Icon JSON</dfn> may have the following properties:
         [maskable](https://www.w3.org/TR/appmanifest/#icon-masks) specification.
     :   <dfn>size</dfn> (optional)
     ::  The size of the icon. The icon is assumed to be square and single resolution
-        (not a multi-resolution .ico). The size may be ommitted if the icon is in
+        (not a multi-resolution .ico). The size may be omitted if the icon is in
         a vector graphic format (like SVG).
 </dl>
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -519,8 +519,39 @@ The file is parsed expecting the following properties:
     :   <dfn>id_token_endpoint</dfn> (required)
     ::  A URL that points to an HTTP API that complies with the [[#idp-api-id-token-endpoint]] API.
     :   <dfn>revocation_endpoint</dfn> (required)
-    :: A URL that points to an HTTP API that complies with the [[#idp-api-revocation-endpoint]] API.
+    ::  A URL that points to an HTTP API that complies with the [[#idp-api-revocation-endpoint]] API.
+    :   <dfn>branding</dfn> (optional)
+    ::  A set of [=Branding JSON=] options.
 </dl>
+
+The <dfn>Branding JSON</dfn> enables an [=IDP=] to express their branding preferences, which may be used by User Agents to customize the user agent consent prompt.
+
+Note: The branding preferences are deliberately designed to be high level / abstract (rather than opinionated about a specific UI structure), to enable different [=User Agents=] to offer different UI experiences and for them to evolve independently over time.
+
+It may have the following properties:
+<dl dfn-type="argument" dfn-for="manifest_branding">
+    :   <dfn>background_color</dfn> (optional)
+    ::  background [=color=] for [=IDP=]-branded widgets such as buttons.
+    :   <dfn>color</dfn> (optional)
+    ::  [=color=] for text on widgets with [=background_color=].
+    :   <dfn>icons</dfn> (optional)
+    ::  A list of [=Icon JSON=] objects.
+</dl>
+
+The <dfn>Icon JSON</dfn> may have the following properties:
+
+<dl dfn-type="argument" dfn-for="manifest_branding_icons">
+    :   <dfn>url</dfn> (required)
+    ::  The url pointing to the icon image.
+        The icon needs to comply with the [maskable](https://www.w3.org/TR/appmanifest/#icon-masks)
+        specification.
+    :   <dfn>size</dfn> (optional)
+    ::  The size of the icon. The icon is assumed to be square and single resolution
+        (not a multi-resolution .ico). The size should be ommitted if the icon is in
+        a vector graphic format (like SVG).
+</dl>
+
+The <dfn>color</dfn> is a subset of CSS <<color>> syntax, namely <<hex-color>>s, ''hsl()''s, ''rgb()''s and <<named-color>>.
 
 For example:
 
@@ -530,7 +561,15 @@ For example:
   "accounts_endpoint": "/accounts.php",
   "client_id_metadata_endpoint": "/metadata.php",
   "id_token_endpoint": "/idtokens.php",
-  "revocation_endpoint": "/revocation.php"
+  "revocation_endpoint": "/revocation.php",
+  "branding": {
+    "background_color": "green",
+    "color": "0xFFEEAA",
+    "icons": [{
+      "url": "https://idp.example/icon.ico",
+      "size": 10,
+    }]
+  }
 }
 ```
 </div>
@@ -564,8 +603,6 @@ The response is expected to have the following properties:
 <dl dfn-type="argument" dfn-for="accounts_endpoint_response">
     :   <dfn>accounts</dfn> (required)
     ::  A list of [=Account JSON=].
-    :   <dfn>branding</dfn> (optional)
-    ::  A set of [=Branding JSON=] options.
 </dl>
 
 Every <dfn>Account JSON</dfn> is expected to have the following properties:
@@ -582,28 +619,6 @@ Every <dfn>Account JSON</dfn> is expected to have the following properties:
     :   <dfn>approved_clients</dfn> (optional)
     ::  A list of [=RP=]s (in the form of Client IDs) this account is already registered with.
 </dl>
-
-The <dfn>Branding JSON</dfn> is expected to have the following properties:
-
-<dl dfn-type="argument" dfn-for="accounts_endpoint_response_branding">
-    :   <dfn>background_color</dfn> (optional)
-    ::  The background [=color=] of the button.
-    :   <dfn>foreground_color</dfn> (optional)
-    ::  The foreground [=color=] of the button.
-    :   <dfn>icons</dfn> (optinal)
-    ::  A list of [=Icon JSON=] objects.
-</dl>
-
-The <dfn>Icon JSON</dfn> is expected to have the following properties:
-
-<dl dfn-type="argument" dfn-for="accounts_endpoint_response_branding_icons">
-    :   <dfn>url</dfn> (required)
-    ::  The url pointing to the icon image.
-    :   <dfn>size</dfn> (optional)
-    ::  The size of the icon (assumed to be squared).
-</dl>
-
-The <dfn>color</dfn> is a subset of CSS <<color>> syntax, namely <<hex-color>>s, ''hsl()''s, ''rgb()''s and <<named-color>>.
 
 For example:
 
@@ -624,15 +639,7 @@ For example:
    "email": "johnny@idp.example",
    "picture": "https://idp.example/profile/456"
    "approved_clients": ["abc", "def", "ghi"],
-  }],
-  "branding": {
-   "background_color": "green",
-   "foreground_color": "0xFFEEAA",
-   "icons": [{
-     "url": "https://idp.example/icon.ico",
-     "size": 10
-   }],
- }
+  }]
 }
 ```
 </div>


### PR DESCRIPTION
This PR subsumes https://github.com/fedidcg/FedCM/pull/182

This PR:
- reflects the soon to be landed changes to the branding information. It does not include dark-mode parameters.
- adds more details about the nature of icons listed in the manifest. They should adhere to the spec for "maskable icons" in the Web Manifest spec and should be single-resolution (not .ico files)

Note that I use 'background_color' instead of 'background-color' to be consistent with JSON naming conventions rather than being consistent with CSS.

Marked the change as non-substantial because the W3C check was giving me trouble. (I did connect my github and W3C account)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/pkotwicz/FedCM/pull/202.html" title="Last updated on Feb 17, 2022, 11:24 PM UTC (c7cc098)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/fedidcg/FedCM/202/9764bae...pkotwicz:c7cc098.html" title="Last updated on Feb 17, 2022, 11:24 PM UTC (c7cc098)">Diff</a>