### PR TITLE
Update and clarify the spec examples.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -270,36 +270,36 @@ could be implemented.
 
   <script>
   async function login() {
-    const credential = await navigator.credentials.get({
-      federated: {
-        providers: [{
-          url: "https://idp.example",
-          clientId: "123"
-        }]
-      }
-    });
+    const credential = getFederatedCredential();
+
+    // This will prompt when !credential[“consented”], but
+    // it won’t when credential[“consented”].
+    //
+    // If !credential["consented"] and mediation == silent will `reject`.
+    //
+    // If the user selects an account updates the credential["consented"]
+    // state and stores any needed account information.
     return await credential.login({ nonce: "456" });
   }
 
   async function logout() {
-    const credential = getLoggedInCredential();
-    if (credential) {
-      return await credential.logout();
-    }
-    return undefined;
+    const credential = getFederatedCredential();
+    // This never prompts, rejects the promise in case !credential[“consented”]
+    return credential.logout();
   }
 
   async function revoke() {
-    const credential = getLoggedInCredential();
-    if (credential) {
-      return await credential.revoke();
-    }
-    return undefined;
+    const credential = getFederatedCredential();
+    // This never prompts, rejects the promise in case !credential[“consented”]
+    return credential.revoke();
   }
 
-  async function getLoggedInCredential() {
+  async function getFederatedCredential() {
+    // This never prompts. A FederatedCredential object will always be returned.
+    // The object will be either consented or unconsented and store information
+    // on if the user should be prompted based on the mediation flag.
     return await navigator.credentials.get({
-      mediation: "silent",
+      mediated: “optional”, // “optional” is the default
       federated: {
         providers: [{
           url: "https://idp.example",
@@ -367,23 +367,16 @@ could be implemented.
 
   async function logout() {
     const credential = await getLoggedInCredential();
-    if (credential) {
-      credential.logout();
-    }
+    return credential.logout();
   }
 
   async function revoke() {
     const credential = await getLoggedInCredential();
-    if (credential) {
-      credential.revoke();
-    }
+    return credential.revoke();
   }
 
   async function getLoggedInCredential() {
     const id = ...; /* site gets stored id if available */
-    if (id === undefined) {
-      return undefined;
-    }
     return navigator.credentials.get({
       mediation: "silent",
       federated: {
@@ -1061,6 +1054,9 @@ This [=internal method=] accepts three arguments:
          caller's [=environment settings object=] is
          [=same-origin with its ancestors=]. It is [FALSE] if caller is cross-origin.
 </dl>
+
+NOTE: This algorithm is currently out of date and will be updated to match the
+examples.
 
 When this method is invoked, the user agent MUST execute the following algorithm:
 


### PR DESCRIPTION
This PR starts updating the spec to clarify the return value of the
`get` request and make it more consistent. With this new change the
`get` request will never return a `null` value but will return a
FederatedCredential object with the correct consented space.

A followup PR will update the algorithms and other portions of the
spec to reflect this change.

Issue #145


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dj2/FedCM/pull/213.html" title="Last updated on Mar 2, 2022, 6:30 PM UTC (9c119ce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/fedidcg/FedCM/213/3d36277...dj2:9c119ce.html" title="Last updated on Mar 2, 2022, 6:30 PM UTC (9c119ce)">Diff</a>