### PR TITLE
Fix trailing comma in json examples

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -658,7 +658,7 @@ For example:
     "color": "0xFFEEAA",
     "icons": [{
       "url": "https://idp.example/icon.ico",
-      "size": 10,
+      "size": 10
     }]
   }
 }

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -722,14 +722,14 @@ For example:
    "name": "John Doe",
    "email": "john_doe@idp.example",
    "picture": "https://idp.example/profile/123",
-   "approved_clients": ["123", "456", "789"],
+   "approved_clients": ["123", "456", "789"]
   }, {
    "id": "5678",
    "given_name": "Johnny",
    "name": "Johnny",
    "email": "johnny@idp.example",
    "picture": "https://idp.example/profile/456"
-   "approved_clients": ["abc", "def", "ghi"],
+   "approved_clients": ["abc", "def", "ghi"]
   }]
 }
 ```
@@ -778,7 +778,7 @@ For example:
 ```json
 {
   "privacy_policy_url": "https://rp.example/clientmetadata/privacy_policy.html",
-  "terms_of_service_url": "https://rp.example/clientmetadata/terms_of_service.html",
+  "terms_of_service_url": "https://rp.example/clientmetadata/terms_of_service.html"
 }
 ```
 </div>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yi-gu/FedCM/pull/219.html" title="Last updated on Mar 4, 2022, 1:53 AM UTC (383fdbf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/fedidcg/FedCM/219/385f5dd...yi-gu:383fdbf.html" title="Last updated on Mar 4, 2022, 1:53 AM UTC (383fdbf)">Diff</a>