### PR TITLE
Make "email" required in the accounts response

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -703,10 +703,10 @@ Every <dfn>Account JSON</dfn> is expected to have the following properties:
     ::  The account unique identifier.
     :   <dfn>name</dfn> (required)
     ::  The user's full name.
+    :   <dfn>email</dfn> (required)
+    ::  The user's email address.
     :   <dfn>given_name</dfn> (optional)
     ::  The user's given name.
-    :   <dfn>email</dfn> (optional)
-    ::  The user's email address.
     :   <dfn>approved_clients</dfn> (optional)
     ::  A list of [=RP=]s (in the form of Client IDs) this account is already registered with.
 </dl>


### PR DESCRIPTION
When a user is signed in to an IDP with multiple accounts and each of them uses the same name and avatar, the UI would be confusing without an extra bit (e.g. email) for them to differentiate.

This PR makes "email" required and we are open to adjust to relax it if there's need.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yi-gu/FedCM/pull/227.html" title="Last updated on Mar 9, 2022, 8:09 PM UTC (f5e0eb7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/fedidcg/FedCM/227/9c23874...yi-gu:f5e0eb7.html" title="Last updated on Mar 9, 2022, 8:09 PM UTC (f5e0eb7)">Diff</a>