### PR TITLE
Define "Manifest" and use it to add return types to the "Fetch Manifest" algorithm

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1318,7 +1318,7 @@ to keep their actual manifest on an arbitary path while allowing the user agent 
 manipulation to fingerprint. See https://github.com/fedidcg/FedCM/issues/230 for more details on
 this attack.
 
-The <dfn>check the root manifest</dfn> accepts a {{FederatedIdentityProvider}} |provider| and returns true if the manifest is included in the manifest list and false otherwise:
+The <dfn>check the root manifest</dfn> accepts a {{FederatedIdentityProvider}} |provider| and whether the manifest is included in the manifest list:
     1. Let |url| be |provider|'s {{FederatedIdentityProvider/url}}.
     1. Let |rootUrl| be a new [=/URL=].
     1. Set |rootUrl|'s [=url/scheme=] to |url|'s [=url/scheme=].
@@ -1348,6 +1348,7 @@ The <dfn>fetch the internal manifest</dfn> algorithm accepts a {{FederatedIdenti
     1. Let the |manifest url| be the file "fedcm.json" relative to the directory
         prefix passed as |provider|'s {{FederatedIdentityProvider/url}}.
     1. Return the result of fetching the |manifest url| and parsing it into a [=Manifest=].
+        TODO: specify how the fetching and the parsing works.
         The fetch MUST be done with the [[#Sec-FedCM-CSRF|Sec-FedCM-CSRF]] header but
 	without the [=Identity Provider=]'s cookies. This request MUST NOT follow
         [[RFC7231#header.location|HTTP redirects]] and instead abort with an

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -614,7 +614,9 @@ Sec-FedCM-CSRF: ?1
 ```
 </div>
 
-The file is parsed expecting the following properties:
+The file is parsed expecting [=Manifest=] JSON object.
+
+The <dfn>Manifest</dfn> JSON object has the following properties:
 
 <dl dfn-type="argument" dfn-for="Manifest">
     :   <dfn>accounts_endpoint</dfn> (required)
@@ -1242,7 +1244,7 @@ To <dfn>create tokens</dfn>:
         * {{FederatedTokens/idToken}} as |tokens|["id_token"]
     1. <a for=Promise>Resolve</a> |promise| with |tokens| and return |promise|.
 
-To <dfn>fetch the manifest</dfn> given a {{FederatedIdentityProvider}} |provider|:
+The <dfn>fetch the manifest</dfn> algorithm accepts a {{FederatedIdentityProvider}} |provider| and returns a [=Manifest=] object:
     1. In parallel, perform the following two steps:
         1. Let |manifestInSet| be the result of running [=check the root manifest=], passing
             |provider|.
@@ -1258,7 +1260,7 @@ to keep their actual manifest on an arbitary path while allowing the user agent 
 manipulation to fingerprint. See https://github.com/fedidcg/FedCM/issues/230 for more details on
 this attack.
 
-To <dfn>check the root manifest</dfn> given a {{FederatedIdentityProvider}} |provider|:
+The <dfn>check the root manifest</dfn> accepts a {{FederatedIdentityProvider}} |provider| and returns true if the manifest is included in the manifest list and false otherwise:
     1. Let |url| be |provider|'s {{FederatedIdentityProvider/url}}.
     1. Let |rootUrl| be a new [=/URL=].
     1. Set |rootUrl|'s [=url/scheme=] to |url|'s [=url/scheme=].
@@ -1281,15 +1283,15 @@ To <dfn>check the root manifest</dfn> given a {{FederatedIdentityProvider}} |pro
         1. Return true if |json|["provider_urls"][0] [=string/is=] equal to |provider|'s
             {{FederatedIdentityProvider/url}}, otherwise return false.
 
-To <dfn>fetch the internal manifest</dfn> given a {{FederatedIdentityProvider}} |provider|:
+The <dfn>fetch the internal manifest</dfn> algorithm accepts a {{FederatedIdentityProvider}} |provider| and returns a [=Manifest=]:
     1. Run a [[!CSP]] check with a [[CSP#directive-connect-src|connect-src]]
         directive on the URL passed as |provider|'s {{FederatedIdentityProvider/url}}
         and return if the check fails.
     1. Let the |manifest url| be the file "fedcm.json" relative to the directory
         prefix passed as |provider|'s {{FederatedIdentityProvider/url}}.
-    1. Return the result of fetching the |manifest url| with the
-        [[#Sec-FedCM-CSRF|Sec-FedCM-CSRF]] header but without the
-        [=Identity Provider=]'s cookies.  This request MUST NOT follow
+    1. Return the result of fetching the |manifest url| and parsing it into a [=Manifest=].
+        The fetch MUST be done with the [[#Sec-FedCM-CSRF|Sec-FedCM-CSRF]] header but
+	without the [=Identity Provider=]'s cookies. This request MUST NOT follow
         [[RFC7231#header.location|HTTP redirects]] and instead abort with an
         error if there are any.
 


### PR DESCRIPTION
Start adding return types to algorithms to make them more precise. Will add more as I go along.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fedidcg/FedCM/pull/271.html" title="Last updated on Jun 8, 2022, 3:54 PM UTC (c654f3c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/fedidcg/FedCM/271/1ccd28d...c654f3c.html" title="Last updated on Jun 8, 2022, 3:54 PM UTC (c654f3c)">Diff</a>