### PR TITLE
Create a new IdentityCredential interface to avoid breaking changes to the existing FederatedCredential

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -287,7 +287,7 @@ entries provided by the [=Identity Provider=].
 # Examples # {#examples}
 <!-- ============================================================ -->
 
-This specification extends the {{FederatedCredential}} type and internal
+This specification defines a new {{IdentityCredential}} type and internal
 algorithms to allow the exchange of identity between [=IDP=]s and [=RP=]s.
 When it succeeds, it returns to the [=RP=] a signed [=id token=] which the
 [=RP=] can use to authenticate the user.
@@ -311,7 +311,7 @@ could be implemented.
 
   <script>
   async function login() {
-    const credential = getFederatedCredential();
+    const credential = getCredential();
 
     // This will prompt when !credential["registered"], but
     // it won’t when credential["registered"].
@@ -321,24 +321,24 @@ could be implemented.
   }
 
   async function logout() {
-    const credential = getFederatedCredential();
+    const credential = getCredential();
     // This never prompts, rejects the promise in case !credential["registered"]
     return credential.logout();
   }
 
   async function revoke() {
-    const credential = getFederatedCredential();
+    const credential = getCredential();
     // This never prompts, rejects the promise in case !credential["registered"]
     return credential.revoke();
   }
 
-  async function getFederatedCredential() {
-    // This never prompts. A FederatedCredential object will always be returned.
+  async function getCredential() {
+    // This never prompts. An IdentityCredential object will always be returned.
     // The object will be either registered or unregistered and store information
     // on if the user should be prompted based on the mediation flag.
     return await navigator.credentials.get({
       mediated: “optional”, // “optional” is the default
-      federated: {
+      identity: {
         providers: [{
           url: "https://idp.example",
           clientId: "123"
@@ -375,7 +375,7 @@ could be implemented.
     const id = ...; /* site gets stored id if available */
     const credential = await navigator.credentials.get({
       mediation: "optional",
-      federated: {
+      identity: {
         providers: [{
           url: "https://idp.example",
           clientId: "123",
@@ -391,7 +391,7 @@ could be implemented.
   async function multiLogin() {
     const credential = await navigator.credentials.get({
       mediation: "required",
-      federated: {
+      identity: {
         providers: [{
           url: "https://idp.example",
           clientId: "123",
@@ -417,7 +417,7 @@ could be implemented.
     const id = ...; /* site gets stored id if available */
     return navigator.credentials.get({
       mediation: "silent",
-      federated: {
+      identity: {
         providers: [{
           url: "https://idp.example",
           clientId: "123",
@@ -1120,15 +1120,16 @@ The user agent keepts track of the following state machine for each
 </dl>
 
 <!-- ============================================================ -->
-## The FederatedCredential Object ## {#browser-api-federated-credential}
+## The CredentialRequestOptions ## {#browser-api-credential-request-options}
 <!-- ============================================================ -->
-The {{FederatedCredential}} object is the primary way to interact with the
-FedCM API.
+
+The main entrypoint in this specification is through the entrypoints exposed
+by the [[CM]] API.
 
 <div class=example>
 ```js
 const credential = await navigator.credentials.get({
-  federated: {
+  identity: {
     providers: [{
       url: "https://idp.example",
       clientId: "123",
@@ -1139,19 +1140,25 @@ const credential = await navigator.credentials.get({
 ```
 </div>
 
-The most important parameter to the API call is the set of
-[=Identity Provider=]s that the [=Relying Party=] supports and has
+This specification starts by introducing an extension to the
+{{CredentialRequestOptions}} object:
+
+<pre class="idl">
+  partial dictionary CredentialRequestOptions {
+    IdentityCredentialRequestOptions identity;
+  };
+</pre>
+
+The {{IdentityCredentialRequestOptions}} contains a list of
+{{IdentityProvider}}s that the [=Relying Party=] supports and has
 pre-registered with (i.e. it has a `clientId`).
 
-The set of [=Identity Provider=]s is an extension to the
-{{FederatedCredentialRequestOptions}} adding a list of {{FederatedIdentityProvider}}s:
-
 <xmp class=idl>
-partial dictionary FederatedCredentialRequestOptions {
-  sequence<(DOMString or FederatedIdentityProvider)> providers;
+dictionary IdentityCredentialRequestOptions {
+  sequence<IdentityProvider> providers;
 };
 
-dictionary FederatedIdentityProvider {
+dictionary IdentityProvider {
   required USVString url;
   required USVString clientId;
   USVString hint;
@@ -1163,7 +1170,7 @@ NOTE: The {{CredentialRequestOptions/mediation}} flag is currently not used.
 The {{CredentialRequestOptions/signal}} is used as an abort signal for the
 requests.
 
-<dl dfn-type="argument" dfn-for="FederatedIdentityProvider">
+<dl dfn-type="argument" dfn-for="IdentityProvider">
     :   <dfn>url</dfn>
     ::  The URL of the identity provider.
     :   <dfn>clientId</dfn>
@@ -1173,21 +1180,33 @@ requests.
          account chooser dialog.
 </dl>
 
-This specification overrides the {{FederatedCredential}}'s
-<code><dfn for="FederatedCredential" method>
+<!-- ============================================================ -->
+## The IdentityCredential Interface ## {#browser-api-identity-credential-interface}
+<!-- ============================================================ -->
+
+This specification introduces a new type of {{Credential}}, called an {{IdentityCredential}}:
+
+<pre class="idl">
+  [Exposed=Window, SecureContext]
+  interface IdentityCredential : Credential {
+  };
+</pre>
+
+It also overrides the {{IdentityCredential}}'s
+<code><dfn for="IdentityCredential" method>
  \[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)</dfn></code>
 method.
 
-Each {{FederatedCredential}} has an associated <dfn>provider</dfn>, a
-{{FederatedIdentityProvider}}, which is initially null.
+Each {{IdentityCredential}} has an associated <dfn>provider</dfn>, a
+{{IdentityProvider}}, which is initially null.
 
 This algorithm runs in parallel inside the [[CM#algorithm-request]] to request
-credentials and returns a set of {{FederatedCredential}} for the requested
+credentials and returns a set of {{IdentityCredential}} for the requested
 [=Identity Provider=]s.
 
 This [=internal method=] accepts three arguments:
 
-<dl dfn-type="argument" dfn-for="FederatedCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)">
+<dl dfn-type="argument" dfn-for="IdentityCredential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)">
     :   <dfn>origin</dfn>
     ::  This argument is the [=relevant settings object=]'s
          [=environment settings object/origin=], as determined by the
@@ -1196,8 +1215,8 @@ This [=internal method=] accepts three arguments:
          abstract operation.
     :   <dfn>options</dfn>
     ::  This argument is a {{CredentialRequestOptions}} object whose
-         <code>|options|.{{CredentialRequestOptions/federated}}</code> member
-         contains a {{FederatedCredentialRequestOptions}} object specifying the
+         <code>|options|.{{CredentialRequestOptions/identity}}</code> member
+         contains a {{IdentityCredentialRequestOptions}} object specifying the
          exchange options.
     :   <dfn>sameOriginWithAncestors</dfn>
     ::  This argument is a Boolean value which is [TRUE] if and only if the
@@ -1212,14 +1231,14 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
       Note: This restriction aims to address the concern raised
       in [[Security-Origin-Confusion]].
-  1.  Assert: |options|["{{CredentialRequestOptions/federated}}"]["{{FederatedCredentialRequestOptions/providers}}"] [=map/exists=].
-  1.  Assert: |options|["{{CredentialRequestOptions/federated}}"]["{{FederatedCredentialRequestOptions/providers}}"] [=list/size=] is 1.
+  1.  Assert: |options|["{{CredentialRequestOptions/identity}}"]["{{IdentityCredentialRequestOptions/providers}}"] [=map/exists=].
+  1.  Assert: |options|["{{CredentialRequestOptions/identity}}"]["{{IdentityCredentialRequestOptions/providers}}"] [=list/size=] is 1.
 
        Note: At some point we would like to support choosing accounts from
        multiple [=Identity Provider=]s.
-  1. Let |provider| be |options|["{{CredentialRequestOptions/federated}}"]["{{FederatedCredentialRequestOptions/providers}}"][0].
-  1. Let |hint| be |provider|["{{FederatedIdentityProvider/hint}}"]
-  1. Let |credential| be a new {{FederatedCredential}}.
+  1. Let |provider| be |options|["{{CredentialRequestOptions/identity}}"]["{{IdentityCredentialRequestOptions/providers}}"][0].
+  1. Let |hint| be |provider|["{{IdentityProvider/hint}}"]
+  1. Let |credential| be a new {{IdentityCredential}}.
   1. Set |credential|'s <a>provider</a> to |provider|.
   1. Set |credential|'s {{Credential/id}} to |hint|.
   1. Return |credential|
@@ -1262,7 +1281,7 @@ dictionary FederatedAccountLoginRequest {
 };
 
 [Exposed=Window, SecureContext]
-partial interface FederatedCredential {
+partial interface IdentityCredential {
   Promise<FederatedTokens> login(optional FederatedAccountLoginRequest request = {});
 };
 
@@ -1306,7 +1325,7 @@ To <dfn>request consent</dfn>:
 To <dfn>fetch the accounts list</dfn>:
     1. Let the |accounts_endpoint| url be the relative url
         |manifest|["{{Manifest/accounts_endpoint}}"] of
-        |provider|["{{FederatedIdentityProvider/url}}"]
+        |provider|["{{IdentityProvider/url}}"]
     1. Let the |accounts list| be the result of fetching the |accounts_endpoint|
         with the [=Identity Provider=]'s cookies.  This request MUST NOT follow
         [[RFC9110#header.location|HTTP redirects]] and instead abort with an
@@ -1318,10 +1337,10 @@ To <dfn>sign-up</dfn> the user with a given |account|:
     1. Let |metadata| be the result of running the [=fetch the client metadata=]
         algorithm.
     1. If |metadata|["{{client_metadata_endpoint_response/privacy_policy_url}}"] is defined and
-        the provider["{{FederatedIdentityProvider/clientId}}"] is not in the list of |account|["{{accounts_endpoint_response_accounts/approved_clients}}"]
+        the provider["{{IdentityProvider/clientId}}"] is not in the list of |account|["{{accounts_endpoint_response_accounts/approved_clients}}"]
         then display the |metadata|["{{client_metadata_endpoint_response/privacy_policy_url}}"] link.
     1. If |metadata|["terms_of_service_url"] is defined and
-        the provider["{{FederatedIdentityProvider/clientId}}"] is not in the list of |account|["{{accounts_endpoint_response_accounts/approved_clients}}"]
+        the provider["{{IdentityProvider/clientId}}"] is not in the list of |account|["{{accounts_endpoint_response_accounts/approved_clients}}"]
 	      then display the |metadata|["{{client_metadata_endpoint_response/terms_of_service_url}}"] link.
     1. Prompt the user to gather explicit intent to create an account. The user agent MAY use the
         [=Branding JSON=] to inform the style choices of its UI.
@@ -1333,7 +1352,7 @@ To <dfn>sign-up</dfn> the user with a given |account|:
 To <dfn noexport>fetch the client metadata</dfn>:
     1. Let the |client_metadata_endpoint| url be the relative url
         |manifest|["{{Manifest/client_metadata_endpoint}}"] of
-        |provider|["{{FederatedIdentityProvider/url}}"]
+        |provider|["{{IdentityProvider/url}}"]
     1. Let the |policies| be the result of fetching the
         |client_metadata_endpoint| with the [[#Sec-FedCM-CSRF|Sec-FedCM-CSRF]]
         header but without the [=Identity Provider=]'s cookies.  This request
@@ -1344,8 +1363,8 @@ To <dfn noexport>fetch the client metadata</dfn>:
 To <dfn>select an account</dfn> from the accounts list:
     1. If |accounts list|'s [=list/size=] is 1:
         1. Let |account| be |accounts list|[0] and return |account|
-    1. If this's {{FederatedCredential/provider}}["accountId"] is provided and
-        an account matches this's {{FederatedCredential/provider}}["accountId"] then return
+    1. If this's {{IdentityCredential/provider}}["accountId"] is provided and
+        an account matches this's {{IdentityCredential/provider}}["accountId"] then return
         |account|.
     1. Display an account chooser
     1. Let |account| be an account that the user manually selects from the
@@ -1362,7 +1381,7 @@ To <dfn>create tokens</dfn>:
     1. Assert {{StateMachine/Session State}} is [=logged-in=]
     1. Let |request| be a new object
         1. Set |request|["account_id"] to |account|["{{accounts_endpoint_response_accounts/id}}"].
-        1. Set |request|["client_id"] to |provider|["{{FederatedIdentityProvider/clientId}}"].
+        1. Set |request|["client_id"] to |provider|["{{IdentityProvider/clientId}}"].
         1. Set |request|["nonce"] to |request|["{{FederatedAccountLoginRequest/nonce}}"].
     1. Let |tokens| be the result of making a POST request described in
         [[#idp-api-id-token-endpoint]].
@@ -1371,7 +1390,7 @@ To <dfn>create tokens</dfn>:
         * {{FederatedTokens/idToken}} as |tokens|["id_token"]
     1. <a for=Promise>Resolve</a> |promise| with |tokens| and return |promise|.
 
-The <dfn>fetch the manifest</dfn> algorithm accepts a {{FederatedIdentityProvider}} |provider| and returns a [=Manifest=] object:
+The <dfn>fetch the manifest</dfn> algorithm accepts a {{IdentityProvider}} |provider| and returns a [=Manifest=] object:
     1. In parallel, perform the following two steps:
         1. Let |manifestInSet| be the result of running [=check the root manifest=], passing
             |provider|.
@@ -1387,8 +1406,8 @@ to keep their actual manifest on an arbitary path while allowing the user agent 
 manipulation to fingerprint. See https://github.com/fedidcg/FedCM/issues/230 for more details on
 this attack.
 
-The <dfn>check the root manifest</dfn> accepts a {{FederatedIdentityProvider}} |provider| and whether the manifest is included in the manifest list:
-    1. Let |url| be |provider|'s {{FederatedIdentityProvider/url}}.
+The <dfn>check the root manifest</dfn> accepts a {{IdentityProvider}} |provider| and whether the manifest is included in the manifest list:
+    1. Let |url| be |provider|'s {{IdentityProvider/url}}.
     1. Let |rootUrl| be a new [=/URL=].
     1. Set |rootUrl|'s [=url/scheme=] to |url|'s [=url/scheme=].
     1. Set |rootUrl|'s [=url/host=] to |url|'s [=url/host=]'s [=host/registrable domain=].
@@ -1408,14 +1427,14 @@ The <dfn>check the root manifest</dfn> accepts a {{FederatedIdentityProvider}} |
             determine the right value, probably greater than 1.
         1. If |json|["provider_urls"][0] is not a [=string=], return false.
         1. Return true if |json|["provider_urls"][0] [=string/is=] equal to |provider|'s
-            {{FederatedIdentityProvider/url}}, otherwise return false.
+            {{IdentityProvider/url}}, otherwise return false.
 
-The <dfn>fetch the internal manifest</dfn> algorithm accepts a {{FederatedIdentityProvider}} |provider| and returns a [=Manifest=]:
+The <dfn>fetch the internal manifest</dfn> algorithm accepts a {{IdentityProvider}} |provider| and returns a [=Manifest=]:
     1. Run a [[!CSP]] check with a [[CSP#directive-connect-src|connect-src]]
-        directive on the URL passed as |provider|'s {{FederatedIdentityProvider/url}}
+        directive on the URL passed as |provider|'s {{IdentityProvider/url}}
         and return if the check fails.
     1. Let the |manifest url| be the file "fedcm.json" relative to the directory
-        prefix passed as |provider|'s {{FederatedIdentityProvider/url}}.
+        prefix passed as |provider|'s {{IdentityProvider/url}}.
     1. Return the result of fetching the |manifest url| and parsing it into a [=Manifest=].
         TODO: specify how the fetching and the parsing works.
         The fetch MUST be done with the [[#Sec-FedCM-CSRF|Sec-FedCM-CSRF]] header but
@@ -1440,12 +1459,12 @@ credential.revoke('user@idp.example');
 ```
 </div>
 
-This specification extends the {{FederatedCredential}} interface with a `revoke`
+This specification extends the {{IdentityCredential}} interface with a `revoke`
 method:
 
 <xmp class=idl>
 [Exposed=Window, SecureContext]
-partial interface FederatedCredential {
+partial interface IdentityCredential {
   Promise<undefined> revoke(USVString hint);
 };
 </xmp>
@@ -1462,7 +1481,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
         promises.
   1. Let the |revocation_endpoint| url be the relative url
         |manifest|["{{Manifest/revocation_endpoint}}"] of
-        |provider|["{{FederatedIdentityProvider/url}}"]
+        |provider|["{{IdentityProvider/url}}"]
     1. Fetch the |revocation_endpoint| with the [=Identity Provider=]'s
         cookies.  This request MUST NOT follow
         [[RFC9110#header.location|HTTP redirects]] and instead abort with an
@@ -1491,12 +1510,12 @@ credential.logout();
 ```
 </div>
 
-This specification extends the {{FederatedCredential}} interface with a `logout`
+This specification extends the {{IdentityCredential}} interface with a `logout`
 method:
 
 <xmp class=idl>
 [Exposed=Window, SecureContext]
-partial interface FederatedCredential {
+partial interface IdentityCredential {
   Promise<undefined> logout();
 };
 </xmp>
@@ -1538,7 +1557,7 @@ path: img/mock31.svg
 
 <div class=example>
 ```js
-await FederatedCredential.logoutRPs([{
+await IdentityCredential.logoutRPs([{
     url: "https://rp1.example",
     accountId: "123"
   }, {
@@ -1548,18 +1567,18 @@ await FederatedCredential.logoutRPs([{
 ```
 </div>
 
-[=IDP=]s can call <code><a idl for="FederatedCredential" lt="logout()">FederatedCredential.logoutRPs(...)</a></code>
+[=IDP=]s can call <code><a idl for="IdentityCredential" lt="logout()">IdentityCredential.logoutRPs(...)</a></code>
 to log the user out of the [=RP=]s they are signed into.
 
 <xmp class=idl>
-dictionary FederatedCredentialLogoutRpsRequest {
+dictionary IdentityCredentialLogoutRpsRequest {
   required USVString url;
   required USVString accountId;
 };
 
 [Exposed=Window, SecureContext]
-partial interface FederatedCredential {
-  static Promise<undefined> logoutRPs(sequence<FederatedCredentialLogoutRpsRequest> logoutRequests);
+partial interface IdentityCredential {
+  static Promise<undefined> logoutRPs(sequence<IdentityCredentialLogoutRpsRequest> logoutRequests);
 };
 </xmp>
 
@@ -1568,12 +1587,12 @@ When this method is invoked, the user agent MUST execute the following algorithm
   1. Let |promise| be a new {{Promise}}.
   1. For each |request| in |logoutRequests|
     1. Let |credential| be a credential matching
-        |request|'s {{FederatedCredentialLogoutRpsRequest/url}} and
-        |request|'s {{FederatedCredentialLogoutRpsRequest/accountId}}
+        |request|'s {{IdentityCredentialLogoutRpsRequest/url}} and
+        |request|'s {{IdentityCredentialLogoutRpsRequest/accountId}}
     1. If no matching |credential| continue
     1. If the |credential| {{StateMachine/Account State}} is [=unregistered=] or
         {{StateMachine/Session State}} is [=logged-out=] continue
-    1. POST to the |request|'s {{FederatedCredentialLogoutRpsRequest/url}} with the
+    1. POST to the |request|'s {{IdentityCredentialLogoutRpsRequest/url}} with the
         [=Relying Parties=] cookies.  This request MUST NOT follow
         [[RFC9110#header.location|HTTP redirects]] and instead abort the request.
     1. Set the |credential| {{StateMachine/Session State}} to [=logged-out=]

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1197,7 +1197,7 @@ It also overrides the {{IdentityCredential}}'s
  \[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)</dfn></code>
 method.
 
-Each {{IdentityCredential}} has an associated <dfn>provider</dfn>, a
+Each {{IdentityCredential}} has an associated <dfn>provider</dfn>, an
 {{IdentityProvider}}, which is initially null.
 
 This algorithm runs in parallel inside the [[CM#algorithm-request]] to request
@@ -1216,7 +1216,7 @@ This [=internal method=] accepts three arguments:
     :   <dfn>options</dfn>
     ::  This argument is a {{CredentialRequestOptions}} object whose
          <code>|options|.{{CredentialRequestOptions/identity}}</code> member
-         contains a {{IdentityCredentialRequestOptions}} object specifying the
+         contains an {{IdentityCredentialRequestOptions}} object specifying the
          exchange options.
     :   <dfn>sameOriginWithAncestors</dfn>
     ::  This argument is a Boolean value which is [TRUE] if and only if the
@@ -1390,7 +1390,7 @@ To <dfn>create tokens</dfn>:
         * {{FederatedTokens/idToken}} as |tokens|["id_token"]
     1. <a for=Promise>Resolve</a> |promise| with |tokens| and return |promise|.
 
-The <dfn>fetch the manifest</dfn> algorithm accepts a {{IdentityProvider}} |provider| and returns a [=Manifest=] object:
+The <dfn>fetch the manifest</dfn> algorithm accepts an {{IdentityProvider}} |provider| and returns a [=Manifest=] object:
     1. In parallel, perform the following two steps:
         1. Let |manifestInSet| be the result of running [=check the root manifest=], passing
             |provider|.
@@ -1406,7 +1406,7 @@ to keep their actual manifest on an arbitary path while allowing the user agent 
 manipulation to fingerprint. See https://github.com/fedidcg/FedCM/issues/230 for more details on
 this attack.
 
-The <dfn>check the root manifest</dfn> accepts a {{IdentityProvider}} |provider| and whether the manifest is included in the manifest list:
+The <dfn>check the root manifest</dfn> accepts an {{IdentityProvider}} |provider| and whether the manifest is included in the manifest list:
     1. Let |url| be |provider|'s {{IdentityProvider/url}}.
     1. Let |rootUrl| be a new [=/URL=].
     1. Set |rootUrl|'s [=url/scheme=] to |url|'s [=url/scheme=].
@@ -1429,7 +1429,7 @@ The <dfn>check the root manifest</dfn> accepts a {{IdentityProvider}} |provider|
         1. Return true if |json|["provider_urls"][0] [=string/is=] equal to |provider|'s
             {{IdentityProvider/url}}, otherwise return false.
 
-The <dfn>fetch the internal manifest</dfn> algorithm accepts a {{IdentityProvider}} |provider| and returns a [=Manifest=]:
+The <dfn>fetch the internal manifest</dfn> algorithm accepts an {{IdentityProvider}} |provider| and returns a [=Manifest=]:
     1. Run a [[!CSP]] check with a [[CSP#directive-connect-src|connect-src]]
         directive on the URL passed as |provider|'s {{IdentityProvider/url}}
         and return if the check fails.


### PR DESCRIPTION
Subclassing the existing FederatedCredential forces us to make backwards compatible changes to its current deployment, which is proving to be harder than we anticipated. It was worth starting from there, but it has become clear to us that extending isn't worth the cost of making backwards incompatible changes (or a deprecation).

In this PR, we introduce a new interface type, IdentityCredential, which allows us to decouple the FedCM API from the current deployment of FederatedCredential.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fedidcg/FedCM/pull/280.html" title="Last updated on Jun 16, 2022, 10:49 PM UTC (b7c1e96)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/fedidcg/FedCM/280/b6782b2...b7c1e96.html" title="Last updated on Jun 16, 2022, 10:49 PM UTC (b7c1e96)">Diff</a>