### PR TITLE
Improve the StateMachine

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -47,7 +47,8 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/
     type: dfn
         text: origin; for: html-origin-def; url: origin.html#concept-origin
         text: Content-Type Metadata; url: urls-and-fetching.html#content-type
-
+    type: method
+        text: setTimeout; url: timers-and-user-prompts.html#dom-settimeout
 
 spec: webidl; urlPrefix: https://webidl.spec.whatwg.org/
     for: Promise
@@ -428,7 +429,7 @@ provides the main security boundary on the web.
     * [[OIDC-Connect-Core]]
 
 : <dfn>site</dfn>
-:: A set of [=origins=] that are all [=site/same site=] with each other. Note that
+:: A set of [=origins=] that are all [=same site=] with each other. Note that
     there are problems ([[PSL-PROBLEMS]]) with using [=registrable domains=] as
     a logical boundary.
 
@@ -445,12 +446,10 @@ provides the main security boundary on the web.
     site may or may not know that multiple user identifiers refer to the same user.
 
 :  <dfn>Privacy Policy</dfn>
-:: The policies described at
-    {{client_metadata_endpoint_response/privacy_policy_url}}.
+:: The policies described at {{client_metadata/privacy_policy_url}}.
 
 :  <dfn>Terms of Service</dfn>
-:: The policies described at
-    {{client_metadata_endpoint_response/terms_of_service_url}}.
+:: The policies described at {{client_metadata/terms_of_service_url}}.
 
 : <dfn>registered</dfn>
 :: The account is `registered` if the user agent thinks that the user has registered an account in
@@ -641,8 +640,7 @@ It may have the following properties:
     :   <dfn>background_color</dfn> (optional)
     ::  Background [=color=] for [=IDP=]-branded widgets such as buttons.
     :   <dfn>color</dfn> (optional)
-    ::  [=color=] for text on [=IDP=] branded widgets using
-        [=background_color=].
+    ::  [=color=] for text on [=IDP=] branded widgets.
     :   <dfn>icons</dfn> (optional)
     ::  A list of [=Icon JSON=] objects.
 </dl>
@@ -790,7 +788,7 @@ Sec-FedCM-CSRF: ?1
 
 The file is parsed expecting the following properties:
 
-<dl dfn-type="argument" dfn-for="client_metadata_endpoint_response">
+<dl dfn-type="argument" dfn-for="client_metadata">
     :   <dfn>privacy_policy_url</dfn> (optional)
     ::  A link to the [=RP=]'s [=privacy policy=].
     :   <dfn>terms_of_service_url</dfn> (optional)
@@ -984,8 +982,8 @@ This specification introduces a new type of {{Credential}}, called an {{Identity
   };
 </pre>
 
-<dl dfn-type="argument" dfn-for="IdentityCredential">
-    :   <dfn>token</dfn>
+<dl>
+    :   <b>{{IdentityCredential/token}}</b>
     ::  The {{IdentityCredential/token}}'s attribute getter returns the value it is set to.
         It represents the minted [=token=] provided by the [=IDP=].
 </dl>
@@ -1027,12 +1025,12 @@ dictionary IdentityProvider {
 };
 </xmp>
 
-<dl dfn-type="argument" dfn-for="IdentityProvider">
-    :   <dfn>configURL</dfn>
+<dl>
+    :   <b>{{IdentityProvider/configURL}}</b>
     ::  The URL of the configuration file for the identity provider.
-    :   <dfn>clientId</dfn>
+    :   <b>{{IdentityProvider/clientId}}</b>
     ::  The [=client id=] provided to the [=RP=] out of band by the [=IDP=]
-    :   <dfn>nonce</dfn>
+    :   <b>{{IdentityProvider/nonce}}</b>
     ::  A random number of the choice of the [=RP=]. It is generally used to associate a client
         session with a [=token=] and to mitigate replay attacks. Therefore, this value should have
         sufficient entropy such that it would be hard to guess.
@@ -1057,9 +1055,8 @@ This [=internal method=] accepts three arguments:
          abstract operation.
     :   <dfn>options</dfn>
     ::  This argument is a {{CredentialRequestOptions}} object whose
-         <code>|options|.{{CredentialRequestOptions/identity}}</code> member
-         contains an {{IdentityCredentialRequestOptions}} object specifying the
-         exchange options.
+        {{CredentialRequestOptions/identity}} member contains an
+        {{IdentityCredentialRequestOptions}} object specifying the exchange options.
     :   <dfn>sameOriginWithAncestors</dfn>
     ::  This argument is a Boolean value which is [TRUE] if and only if the
          caller's [=environment settings object=] is
@@ -1076,7 +1073,7 @@ requests.
     <dfn for="IdentityCredential" method>\[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)</dfn>\
     algorithm is invoked, the user agent MUST execute the following steps:
 
-      1.  If <var ignore>sameOriginWithAncestors</var> is `false`, return a
+      1.  If <var ignore>sameOriginWithAncestors</var> is `false`, throw a
           "{{NotAllowedError}}" {{DOMException}}.
 
           Note: This restriction aims to address the concern raised
@@ -1087,13 +1084,21 @@ requests.
            Note: At some point we would like to support choosing accounts from
            multiple [=Identity Provider=]s.
       1. Let |provider| be |options|["{{CredentialRequestOptions/identity}}"]["{{IdentityCredentialRequestOptions/providers}}"][0].
-      1. Return the [=potentially create IdentityCredential=] algorithm with |provider|.
+      1. Let |credential| be the result of running the [=potentially create IdentityCredential=]
+          algorithm with |provider|.
+      1. If |credential| is null, run {{setTimeout}} passing a [=task=] which throws a
+          {{NetworkError}}, after a timeout of 3 seconds.
+
+          Note: the purpose of having a timer here is to avoid leaking the reason causing this
+          method to return null. If there was no such timer, the developer could easily infer
+          whether the user has an account with the [=IDP=] or not, or whether the user closed the UI without providing consent to share the [=IDP=] account information with the [=RP=].
 </div>
 
 <div algorithm>
 To <dfn>potentially create IdentityCredential</dfn>, given an {{IdentityProvider}} |provider|:
     1. Let |manifest| be the result of running the [=fetch the manifest=]
         algorithm with |provider|.
+    1. If |manifest| is null, return null.
     1. Let |accountsList| be the result of running the
         [=fetch the accounts list=] algorithm with |manifest| and |provider|.
     1. If |accountsList|'s size is 0, return null.
@@ -1141,14 +1146,13 @@ To <dfn>compute account state</dfn> given an {{IdentityProvider}} |provider| and
 <div algorithm>
 To <dfn>fetch the accounts list</dfn> given a [=Manifest=] |manifest| and an {{IdentityProvider}}
     |provider|:
-    1. Let the |accounts_endpoint| url be the relative url
-        |manifest|["{{Manifest/accounts_endpoint}}"] of
-        |provider|["{{IdentityProvider/configURL}}"]
-    1. Let the |accounts list| be the result of fetching the |accounts_endpoint|
-        with the [=Identity Provider=]'s cookies.  This request MUST NOT follow
-        [[RFC9110#header.location|HTTP redirects]] and instead abort with an
-        error if there are any. See also [[#idp-api-accounts-endpoint]].
-    1. Return the |accounts list|.
+    1. Let the |accountsEndpoint| url be the relative url
+        |manifest|["{{Manifest/accounts_endpoint}}"] of |provider|'s {{IdentityProvider/configURL}}.
+    1. Let |accountsList| be the result of fetching the |accountsEndpoint| with the
+        [=Identity Provider=]'s cookies.  This request MUST NOT follow
+        [[RFC9110#header.location|HTTP redirects]] and instead return null if there is any error.
+        See also [[#idp-api-accounts-endpoint]].
+    1. Return |accountsList|.
 </div>
 
 Issue: the [=fetch the accounts list=] algorithm needs to use [=fetch=] appropriately.
@@ -1159,12 +1163,15 @@ To <dfn>request consent to sign-up</dfn> the user with a given [=Account JSON=] 
     |provider|:
     1. Let |metadata| be the result of running the [=fetch the client metadata=]
         algorithm with |manifest| and |provider|.
-    1. If |metadata|["{{client_metadata_endpoint_response/privacy_policy_url}}"] is defined and
-        the provider["{{IdentityProvider/clientId}}"] is not in the list of |account|["{{account_json/approved_clients}}"]
-        then display the |metadata|["{{client_metadata_endpoint_response/privacy_policy_url}}"] link.
-    1. If |metadata|["terms_of_service_url"] is defined and
-        the provider["{{IdentityProvider/clientId}}"] is not in the list of |account|["{{account_json/approved_clients}}"]
-        then display the |metadata|["{{client_metadata_endpoint_response/terms_of_service_url}}"] link.
+    1. If |metadata| is not null,
+        |metadata|["{{client_metadata/privacy_policy_url}}"] is defined, and the |provider|'s
+        {{IdentityProvider/clientId}} is not in the list of
+        |account|["{{account_json/approved_clients}}"], then display the
+        |metadata|["{{client_metadata/privacy_policy_url}}"] link.
+    1. If |metadata| is not null, |metadata|["{{client_metadata/terms_of_service_url}}"] is defined,
+        and the |provider|'s {{IdentityProvider/clientId}} is not in the list of
+        |account|["{{account_json/approved_clients}}"], then display the
+        |metadata|["{{client_metadata/terms_of_service_url}}"] link.
     1. Prompt the user to gather explicit intent to create an account. The user agent MAY use the
         [=Branding JSON=] to inform the style choices of its UI.
     1. If the user does not provide consent, return.
@@ -1176,14 +1183,12 @@ To <dfn>request consent to sign-up</dfn> the user with a given [=Account JSON=] 
 <div algorithm>
 To <dfn noexport>fetch the client metadata</dfn> given a [=Manifest=] |manifest| and an
     {{IdentityProvider}} |provider|, run the following steps:
-    1. Let the |client_metadata_endpoint| url be the relative url
-        |manifest|["{{Manifest/client_metadata_endpoint}}"] of
-        |provider|["{{IdentityProvider/configURL}}"]
-    1. Let the |policies| be the result of fetching the
-        |client_metadata_endpoint| with the [[#Sec-FedCM-CSRF|Sec-FedCM-CSRF]]
-        header but without the [=Identity Provider=]'s cookies.  This request
-        MUST NOT follow [[RFC9110#header.location|HTTP redirects]] and instead
-        abort with an error if there are any. See also [[#idp-api-client-id-metadata-endpoint]].
+    1. Let the |clientMetadataEndpoint| url be the relative url
+        |manifest|["{{Manifest/client_metadata_endpoint}}"] of |provider|'s
+        {{IdentityProvider/configURL}}.
+    1. Let the |policies| be the result of fetching the |clientMetadataEndpoint| with the
+        [[#Sec-FedCM-CSRF|Sec-FedCM-CSRF]] header but without the [=Identity Provider=]'s cookies.  This request MUST NOT follow [[RFC9110#header.location|HTTP redirects]] and instead return
+        null if there is any error. See also [[#idp-api-client-id-metadata-endpoint]].
     1. Return |policies|.
 </div>
 
@@ -1223,7 +1228,7 @@ The <dfn>fetch the manifest</dfn> algorithm accepts an {{IdentityProvider}} |pro
             |provider|.
         1. Let |manifest| be the result of running [=fetch the internal manifest=], passing
             |provider|.
-    1. If |manifestInSet| is true, return |manifest|, otherwise abort with an error.
+    1. If |manifestInSet| is true, return |manifest|, otherwise return null.
 </div>
 
 NOTE: We use a two-tier manifest list in order to prevent the [=IDP=] to easily determine the [=RP=]
@@ -1261,11 +1266,10 @@ The <dfn>fetch the internal manifest</dfn> algorithm accepts an {{IdentityProvid
         directive on the URL passed as |provider|'s {{IdentityProvider/configURL}}
         and return if the check fails.
     1. Return the result of fetching the |provider|'s {{IdentityProvider/configURL}}
-        and parsing it into a [=Manifest=].
-        TODO: specify how the fetching and the parsing works.
-        The fetch MUST be done with the [[#Sec-FedCM-CSRF|Sec-FedCM-CSRF]] header but
-        without the [=Identity Provider=]'s cookies. This request MUST NOT follow
-        [[RFC9110#header.location|HTTP redirects]] and instead abort with an
+        and parsing it into a [=Manifest=]. TODO: specify how the fetching and the parsing works.
+        The fetch MUST be done with the [[#Sec-FedCM-CSRF|Sec-FedCM-CSRF]] header but without the
+        [=Identity Provider=]'s cookies. This request MUST NOT follow
+        [[RFC9110#header.location|HTTP redirects]] and instead throw an
         error if there are any.
 
 <!-- ============================================================ -->
@@ -1306,8 +1310,8 @@ await IdentityCredential.logoutRPs([{
 ```
 </div>
 
-[=IDP=]s can call <code><a idl for="IdentityCredential" lt="logoutRPs()">IdentityCredential.logoutRPs(...)</a></code>
-to log the user out of the [=RP=]s they are signed into.
+[=IDP=]s can call {{IdentityCredential/logoutRPs()}} to log the user out of the [=RP=]s they are
+signed into.
 
 <xmp class=idl>
 dictionary IdentityCredentialLogoutRpsRequest {
@@ -1321,23 +1325,26 @@ partial interface IdentityCredential {
 };
 </xmp>
 
-When this method is invoked, the user agent MUST execute the following algorithm:
-
-  1. Let |promise| be a new {{Promise}}.
-  1. For each |request| in |logoutRequests|
-    1. Let |rpOrigin| be [=this=]'s [=Document/origin=].
-    1. Let |idpOrigin| be |request|'s {{IdentityCredentialLogoutRpsRequest/url}}'s [=origin=].
-    1. Let |account| be |request|'s {{IdentityCredentialLogoutRpsRequest/accountId}}.
-    1. Let |triple| be (|rpOrigin|, |idpOrigin|, |account|).
-    1. If [=state machine map=][|triple|] does not exist, continue.
-    1. Let |accountState| be [=state machine map=][|triple|].
-    1. If the |accountState|'s {{AccountState/registration state}} is [=unregistered=] or
-        |accountState|'s {{AccountState/allows logout}} is false, continue.
-    1. POST to the |request|'s {{IdentityCredentialLogoutRpsRequest/url}} with the
-        [=Relying Parties=] cookies.  This request MUST NOT follow
-        [[RFC9110#header.location|HTTP redirects]] and instead abort the request.
-    1. Set the |accountState| {{AccountState/allows logout}} to false.
-  1. <a for=Promise>Resolve</a> |promise| with |undefined| and return |promise|.
+<div algorithm=logoutRPs>
+When the {{IdentityCredential/logoutRPs()}} method is invoked given a [=list=] of
+{{IdentityCredentialLogoutRpsRequest}}s |logoutRequests|, the user agent MUST execute the following
+steps:
+    1. Let |promise| be a new {{Promise}}.
+    1. For each |request| in |logoutRequests|
+      1. Let |rpOrigin| be [=this=]'s [=Document/origin=].
+      1. Let |idpOrigin| be |request|'s {{IdentityCredentialLogoutRpsRequest/url}}'s [=origin=].
+      1. Let |account| be |request|'s {{IdentityCredentialLogoutRpsRequest/accountId}}.
+      1. Let |triple| be (|rpOrigin|, |idpOrigin|, |account|).
+      1. If [=state machine map=][|triple|] does not exist, continue.
+      1. Let |accountState| be [=state machine map=][|triple|].
+      1. If the |accountState|'s {{AccountState/registration state}} is [=unregistered=] or
+          |accountState|'s {{AccountState/allows logout}} is false, continue.
+      1. POST to the |request|'s {{IdentityCredentialLogoutRpsRequest/url}} with the
+          [=Relying Parties=] cookies.  This request MUST NOT follow
+          [[RFC9110#header.location|HTTP redirects]] and instead abort the request.
+      1. Set the |accountState| {{AccountState/allows logout}} to false.
+    1. <a for=Promise>Resolve</a> |promise| with [undefined] and return |promise|.
+</div>
 
 
 <!-- ============================================================ -->
@@ -1643,7 +1650,7 @@ following are sample mitigations:
     metrics for the API.
 
 <!-- ============================================================ -->
-### Push Model ### {#push-model}
+### Push Model ### {#push-model-mitigation}
 <!-- ============================================================ -->
 
 Another potential future mitigation for timing attacks is the [=push model=]. The current API is the

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -520,7 +520,7 @@ identity federation.
       | "navigator.credentials.get()" |                                 |
       |------------------------------>|                                 |
       |                               |                                 |
-      |                               | "GET /.well-known/fedcm"        |
+      |                               | "GET /.well-known/web-identity" |
       |                               |-------------------------------->|
       |                               |<--------------------------------| "{"
       |                               |                                 |   "provider_urls: [ ... ]"
@@ -1181,7 +1181,7 @@ The <dfn>check the root manifest</dfn> accepts an {{IdentityProvider}} |provider
     1. Let |rootUrl| be a new [=/URL=].
     1. Set |rootUrl|'s [=url/scheme=] to |url|'s [=url/scheme=].
     1. Set |rootUrl|'s [=url/host=] to |url|'s [=url/host=]'s [=host/registrable domain=].
-    1. Set |rootUrl|'s [=url/path=] to ".well-known/fedcm".
+    1. Set |rootUrl|'s [=url/path=] to ".well-known/web-identity".
     1. Let |request| be a new <a spec=fetch for=/>request</a> whose [=request/url=] is |rootUrl| and
         [=request/redirect mode=] set to "error". TODO: what other fields need to be set?
     1. [=Fetch=] |request| with <a spec=fetch>processResponseConsumeBody</a> set to the following

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -951,24 +951,23 @@ Lastly, it overrides the default implementation of [[#browser-api-rp-sign-in]].
 ## The State Machine ## {#browser-api-state-machine}
 <!-- ============================================================ -->
 
-Internally, the FedCM API manages a set of |credential|s which are associated
-with an [=RP=] and [=IDP=] pair. Those |credential| objects have different
-stages of their accounts. At each stage, the state machine manages the |credential|s
-access to the appropriate browser capabilities.
+Each [=user agent=] keeps track of a global <dfn>state machine map</dfn>, an initially empty
+[=map=]. The [=map/keys=] in the [=state machine map=] are triples of the form (|rp|, |idp|, |account|) where |rp| is
+the [=origin=] of the [=RP=], |idp| is the [=origin=] of the [=IDP=], and |account| is a string representing
+an account identifier. The [=map/values=] in the [=state machine map=] are <dfn>AccountState</dfn> objects which have
+the following properties:
 
-TODO: add an ASCII image to explain how the states fit into the algorithms.
-
-The user agent keepts track of the following state machine for each
-(account, [=RP=]) pair:
-
-<dl dfn-type="argument" dfn-for="StateMachine">
-    :   <dfn>Account State</dfn>
-    ::  Keeps track of whether the user has registered the account in the [=RP=] or not.
+<dl dfn-type="argument" dfn-for="AccountState">
+    :   <dfn>registration state</dfn>
+    ::  Keeps track of whether the user agent is aware that the user has registered an account in
+         the [=RP=] or not.
          Can be [=registered=] or [=unregistered=] (by default).
-    :   <dfn>Session State</dfn>
-    ::  Keeps track of whether the user has an open or closed session.
+    :   <dfn>logged in state</dfn>
+    ::  Keeps track of whether the user appears to be logged into the [=RP=] with the account.
          Can be [=logged-in=] or [=logged-out=] (by default).
 </dl>
+
+TODO: add an ASCII image to explain how the states fit into the algorithms.
 
 <!-- ============================================================ -->
 ## The IdentityCredential Interface ## {#browser-api-identity-credential-interface}
@@ -1069,7 +1068,6 @@ The {{CredentialRequestOptions/signal}} is used as an abort signal for the
 requests.
 
 When this method is invoked, the user agent MUST execute the following algorithm:
-
   1.  If <var ignore>sameOriginWithAncestors</var> is `false`, return a
       "{{NotAllowedError}}" {{DOMException}}.
 
@@ -1082,13 +1080,10 @@ When this method is invoked, the user agent MUST execute the following algorithm
        multiple [=Identity Provider=]s.
   1. Let |provider| be |options|["{{CredentialRequestOptions/identity}}"]["{{IdentityCredentialRequestOptions/providers}}"][0].
   1. Let |credential| be a new {{IdentityCredential}}.
-  1. Request user consent by running the [=request consent=] algorithm with the |provider|.
-  1. If {{StateMachine/Account State}} is [=unregistered=] then return null.
-  1. Let |token| be the result of running the [=create tokens=] algorithm.
-  1. Set |credential|'s {{IdentityCredential/token}} to |token|.
-  1. return |credential|.
+  1. Return the [=request consent=] algorithm with |provider|.
 
-To <dfn>request consent</dfn>:
+<div algorithm>
+To <dfn>request consent</dfn>, given an {{IdentityProvider}} |provider|:
     1. Let |manifest| be the result of running the [=fetch the manifest=]
         algorithm with |provider|.
     1. Let |accounts list| be the result of running the
@@ -1096,10 +1091,26 @@ To <dfn>request consent</dfn>:
     1. Let |account| be the result of running the [=select an account=] from the
         |accounts list| algorithm.
     1. If |account| is null, return.
-    1. If the {{StateMachine/Account State}} is [=unregistered=] then run the
-        [=sign-up=] algorithm for |account|, and return.
-    1. Run the [=sign-in=] algorithm for |account|.
+    1. Let |idpURL| be |provider|'s {{IdentityProvider/configURL}}.
+    1. Let |idpOrigin| be the [=origin=] corresponding to |idpURL|. TODO: specify how to go from
+        string to [=origin=].
+    1. Let |rpOrigin| be [=this=]'s [=Document/origin=].
+    1. Let |accountId| be |account|'s {{accounts_endpoint_response_accounts/id}}.
+    1. Let |triple| be (|rpOrigin|, |idpOrigin|, |accountId|).
+    1. If [=state machine map=][|triple|] does not exist, set [=state machine map=][|triple|] to a
+        new [=AccountState=].
+    1. Let |accountState| be [=state machine map=][|triple|].
+    1. If |accountState|'s {{AccountState/registration state}} is [=unregistered=] then run the
+        [=sign-up=] algorithm for |triple|.
+    1. Otherwise, run the [=sign-in=] algorithm for |triple|.
+    1. If |accountState|'s {{AccountState/registration state}} is [=unregistered=] then return null.
+    1. Let |token| be the result of running the [=create tokens=] algorithm with |accountState|,
+        |accountId|, and |provider|.
+    1. Set |credential|'s {{IdentityCredential/token}} to |token|.
+    1. return |credential|.
+</div>
 
+<div algorithm>
 To <dfn>fetch the accounts list</dfn>:
     1. Let the |accounts_endpoint| url be the relative url
         |manifest|["{{Manifest/accounts_endpoint}}"] of
@@ -1109,8 +1120,12 @@ To <dfn>fetch the accounts list</dfn>:
         [[RFC9110#header.location|HTTP redirects]] and instead abort with an
         error if there are any. See also [[#idp-api-accounts-endpoint]].
     1. Return the |accounts list|.
+</div>
 
-To <dfn>sign-up</dfn> the user with a given |account|:
+Issue: the [=fetch the accounts list=] algorithm needs to use [=fetch=] appropriately.
+
+<div algorithm>
+To <dfn>sign-up</dfn> the user with a given |triple| of (|rpOrigin|, |idpOrigin|, |account|):
     1. Let |metadata| be the result of running the [=fetch the client metadata=]
         algorithm.
     1. If |metadata|["{{client_metadata_endpoint_response/privacy_policy_url}}"] is defined and
@@ -1121,11 +1136,15 @@ To <dfn>sign-up</dfn> the user with a given |account|:
         then display the |metadata|["{{client_metadata_endpoint_response/terms_of_service_url}}"] link.
     1. Prompt the user to gather explicit intent to create an account. The user agent MAY use the
         [=Branding JSON=] to inform the style choices of its UI.
-    1. Set the account's {{StateMachine/Account State}} from [=unregistered=]
-        to [=registered=].
-    1. Set the account's {{StateMachine/Session State}} from [=logged-out=]
-        to [=logged-in=].
+    1. If the user does not provide consent, return.
+    1. Let |accountState| be [=state machine map=][|triple|].
+    1. Change |accountState|'s {{AccountState/registration state}} from [=unregistered=] to
+        [=registered=].
+    1. Change |accountState|'s {{AccountState/logged in state}} from [=logged-out=] to
+        [=logged-in=].
+</div>
 
+<div algorithm>
 To <dfn noexport>fetch the client metadata</dfn>:
     1. Let the |client_metadata_endpoint| url be the relative url
         |manifest|["{{Manifest/client_metadata_endpoint}}"] of
@@ -1136,31 +1155,41 @@ To <dfn noexport>fetch the client metadata</dfn>:
         MUST NOT follow [[RFC9110#header.location|HTTP redirects]] and instead
         abort with an error if there are any. See also [[#idp-api-client-id-metadata-endpoint]].
     1. Return |policies|.
+</div>
 
+<div algorithm>
 To <dfn>select an account</dfn> from the accounts list:
     1. If |accounts list|'s [=list/size=] is 1:
         1. Let |account| be |accounts list|[0] and return |account|
     1. Display an account chooser
-    1. Let |account| be an account that the user manually selects from the
-        accounts chooser, or null if no account is selected.
+    1. Let |account| be the {{accounts_endpoint_response_accounts/id}} of the account that the user
+        manually selects from the accounts chooser, or null if no account is selected.
     1. Return |account|
+</div>
 
-To <dfn>sign-in</dfn> the user:
-    1. Assert that the {{StateMachine/Account State}} is [=registered=]
-    1. Set the account's {{StateMachine/Session State}} from [=logged-out=] to
+<div algorithm>
+To <dfn>sign-in</dfn> the user with a given |triple| of (|rpOrigin|, |idpOrigin|, |account|):
+    1. Let |accountState| be [=state machine map=][|triple|].
+    1. Assert that |accountState|'s {{AccountState/registration state}} is [=registered=]
+    1. Change |accountState|'s {{AccountState/logged in state}} from [=logged-out=] to
         [=logged-in=].
+</div>
 
-To <dfn>create tokens</dfn>:
-    1. Assert {{StateMachine/Account State}} is [=registered=]
-    1. Assert {{StateMachine/Session State}} is [=logged-in=]
+<div algorithm>
+To <dfn>create tokens</dfn> given an [=AccountState=] |accountState|, a {{USVString}} |accountId|,
+    and an {{IdentityProvider}} |provider|:
+    1. Assert |accountState|'s {{AccountState/registration state}} is [=registered=]
+    1. Assert |accountState|'s {{AccountState/logged in state}} is [=logged-in=]
     1. Let |request| be a new object
-        1. Set |request|["account_id"] to |account|["{{accounts_endpoint_response_accounts/id}}"].
-        1. Set |request|["client_id"] to |provider|["{{IdentityProvider/clientId}}"].
-        1. Set |request|["nonce"] to |request|["{{IdentityProvider/nonce}}"].
+        1. Set |request|["account_id"] to |accountId|.
+        1. Set |request|["client_id"] to |provider|'s {{IdentityProvider/clientId}}.
+        1. Set |request|["nonce"] to |provider|'s {{IdentityProvider/nonce}}.
     1. Let |tokens| be the result of making a POST request described in
         [[#idp-api-id-token-endpoint]].
     1. Return |tokens|["token"].
+</div>
 
+<div algorithm>
 The <dfn>fetch the manifest</dfn> algorithm accepts an {{IdentityProvider}} |provider| and returns a [=Manifest=] object:
     1. In parallel, perform the following two steps:
         1. Let |manifestInSet| be the result of running [=check the root manifest=], passing
@@ -1168,6 +1197,7 @@ The <dfn>fetch the manifest</dfn> algorithm accepts an {{IdentityProvider}} |pro
         1. Let |manifest| be the result of running [=fetch the internal manifest=], passing
             |provider|.
     1. If |manifestInSet| is true, return |manifest|, otherwise abort with an error.
+</div>
 
 NOTE: We use a two-tier manifest list in order to prevent the [=IDP=] to easily determine the [=RP=]
 that a user is visiting by encoding the information in the manifest path. We solve this issue by
@@ -1268,16 +1298,19 @@ When this method is invoked, the user agent MUST execute the following algorithm
 
   1. Let |promise| be a new {{Promise}}.
   1. For each |request| in |logoutRequests|
-    1. Let |credential| be a credential matching
-        |request|'s {{IdentityCredentialLogoutRpsRequest/url}} and
-        |request|'s {{IdentityCredentialLogoutRpsRequest/accountId}}
-    1. If no matching |credential| continue
-    1. If the |credential| {{StateMachine/Account State}} is [=unregistered=] or
-        {{StateMachine/Session State}} is [=logged-out=] continue
+    1. Let |rpOrigin| be [=this=]'s [=Document/origin=].
+    1. Let |idpOrigin| be |request|'s {{IdentityCredentialLogoutRpsRequest/url}}'s [=origin=].
+        TODO: origin from string.
+    1. Let |account| be |request|'s {{IdentityCredentialLogoutRpsRequest/accountId}}.
+    1. Let |triple| be (|rpOrigin|, |idpOrigin|, |account|).
+    1. If [=state machine map=][|triple|] does not exist, continue.
+    1. Let |accountState| be [=state machine map=][|triple|].
+    1. If the |accountState|'s {{AccountState/registration state}} is [=unregistered=] or
+        |accountState|'s {{AccountState/logged in state}} is [=logged-out=], continue.
     1. POST to the |request|'s {{IdentityCredentialLogoutRpsRequest/url}} with the
         [=Relying Parties=] cookies.  This request MUST NOT follow
         [[RFC9110#header.location|HTTP redirects]] and instead abort the request.
-    1. Set the |credential| {{StateMachine/Session State}} to [=logged-out=]
+    1. Set the |accountState| {{AccountState/logged in state}} to [=logged-out=]
   1. <a for=Promise>Resolve</a> |promise| with |undefined| and return |promise|.
 
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -448,14 +448,6 @@ provides the main security boundary on the web.
 :: The policies described at
     {{client_metadata_endpoint_response/terms_of_service_url}}.
 
-
-: <dfn>logged-out</dfn>
-:: An account is `logged-out` if the user has either not signed into the account
-    or has signed out.
-
-: <dfn>logged-in</dfn>
-:: An account is `logged-in` if the user has successfully signed into the account.
-
 : <dfn>registered</dfn>
 :: The account is `registered` if the user agent thinks that the user has registered an account in
     the [=RP=] using the account from the [=IDP=].
@@ -959,9 +951,12 @@ the following properties:
     ::  Keeps track of whether the user agent is aware that the user has registered an account in
          the [=RP=] or not.
          Can be [=registered=] or [=unregistered=] (by default).
-    :   <dfn>logged in state</dfn>
-    ::  Keeps track of whether the user appears to be logged into the [=RP=] with the account.
-         Can be [=logged-in=] or [=logged-out=] (by default).
+    :   <dfn>allows logout</dfn>
+    ::  Boolean which keeps track of whether the user agent would allow the |account| to be logged
+        out via {{IdentityCredential/logoutRPs()}}. It is initialized to false by default. Note that
+        this value being true does not imply that the user is logged in to the [=RP=] with the
+        account, it merely implies that {{IdentityCredential/logoutRPs()}} has not yet been called
+        on this account after the last successful {{IdentityCredential}} creation with this account.
 </dl>
 
 TODO: add an ASCII image to explain how the states fit into the algorithms.
@@ -1139,8 +1134,7 @@ To <dfn>sign-up</dfn> the user with a given |triple| of (|rpOrigin|, |idpOrigin|
     1. Let |accountState| be [=state machine map=][|triple|].
     1. Change |accountState|'s {{AccountState/registration state}} from [=unregistered=] to
         [=registered=].
-    1. Change |accountState|'s {{AccountState/logged in state}} from [=logged-out=] to
-        [=logged-in=].
+    1. Change |accountState|'s {{AccountState/allows logout}} from false to true.
 </div>
 
 <div algorithm>
@@ -1170,16 +1164,15 @@ To <dfn>select an account</dfn> from the accounts list:
 To <dfn>sign-in</dfn> the user with a given |triple| of (|rpOrigin|, |idpOrigin|, |account|):
     1. Let |accountState| be [=state machine map=][|triple|].
     1. Assert that |accountState|'s {{AccountState/registration state}} is [=registered=]
-    1. Change |accountState|'s {{AccountState/logged in state}} from [=logged-out=] to
-        [=logged-in=].
+    1. Change |accountState|'s {{AccountState/allows logout}} from false to true.
 </div>
 
 <div algorithm>
 To <dfn>create tokens</dfn> given an [=AccountState=] |accountState|, a {{USVString}} |accountId|,
     and an {{IdentityProvider}} |provider|:
-    1. Assert |accountState|'s {{AccountState/registration state}} is [=registered=]
-    1. Assert |accountState|'s {{AccountState/logged in state}} is [=logged-in=]
-    1. Let |request| be a new object
+    1. Assert |accountState|'s {{AccountState/registration state}} is [=registered=].
+    1. Assert |accountState|'s {{AccountState/allows logout}} is true.
+    1. Let |request| be a new object.
         1. Set |request|["account_id"] to |accountId|.
         1. Set |request|["client_id"] to |provider|'s {{IdentityProvider/clientId}}.
         1. Set |request|["nonce"] to |provider|'s {{IdentityProvider/nonce}}.
@@ -1305,11 +1298,11 @@ When this method is invoked, the user agent MUST execute the following algorithm
     1. If [=state machine map=][|triple|] does not exist, continue.
     1. Let |accountState| be [=state machine map=][|triple|].
     1. If the |accountState|'s {{AccountState/registration state}} is [=unregistered=] or
-        |accountState|'s {{AccountState/logged in state}} is [=logged-out=], continue.
+        |accountState|'s {{AccountState/allows logout}} is false, continue.
     1. POST to the |request|'s {{IdentityCredentialLogoutRpsRequest/url}} with the
         [=Relying Parties=] cookies.  This request MUST NOT follow
         [[RFC9110#header.location|HTTP redirects]] and instead abort the request.
-    1. Set the |accountState| {{AccountState/logged in state}} to [=logged-out=]
+    1. Set the |accountState| {{AccountState/allows logout}} to false.
   1. <a for=Promise>Resolve</a> |promise| with |undefined| and return |promise|.
 
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -731,7 +731,9 @@ Every <dfn>Account JSON</dfn> is expected to have the following properties:
     :   <dfn>given_name</dfn> (optional)
     ::  The user's given name.
     :   <dfn>approved_clients</dfn> (optional)
-    ::  A list of [=RP=]s (in the form of [=Client ID=]s) this account is already registered with. Used in the [=sign-up=] to allow the [=IDP=] to control whether to show the [=Privacy Policy=] and the [=Terms of Service=].
+    ::  A list of [=RP=]s (in the form of [=Client ID=]s) this account is already registered with.
+        Used in the [=request consent to sign-up=] to allow the [=IDP=] to control whether to show
+        the [=Privacy Policy=] and the [=Terms of Service=].
 </dl>
 
 For example:
@@ -831,7 +833,10 @@ It will also contain the following parameters in the request body `application/x
     :   <dfn>account_id</dfn>
     ::  The account identifier that was selected.
     :   <dfn>disclosure_text_shown</dfn>
-    ::  Whether the user agent has explicitly shown to the user what specific information the [=IDP=] intends to share with the [=RP=] (e.g. "idp.example will share your name, email.... with rp.example"), used by the [=sign-up=] algorithm for new users but not by the [=sign-in=] algorithm for returning users.
+    ::  Whether the user agent has explicitly shown to the user what specific information the
+        [=IDP=] intends to share with the [=RP=] (e.g. "idp.example will share your name, email...
+        with rp.example"), used by the [=request consent to sign-up=] algorithm for new users but
+        not by the [=sign-in=] algorithm for returning users.
 </dl>
 
 For example:
@@ -1097,7 +1102,8 @@ To <dfn>request consent</dfn>, given an {{IdentityProvider}} |provider|:
         1. Let |accountState| be the result of running the [=compute account state=] algorithm
             given |provider| and |account|.
         1. If |accountState|'s {{AccountState/registration state}} is [=unregistered=] then run the
-            [=sign-up=] algorithm with |account|, |accountState|, |manifest|, and |provider|.
+            [=request consent to sign-up=] algorithm with |account|, |accountState|, |manifest|, and
+            |provider|.
         1. Otherwise, show a dialog to request user consent to sign in via |account|.
         1. If the user consents, run the [=sign-in=] algorithm with |accountState|.
     1. Otherwise:
@@ -1107,22 +1113,22 @@ To <dfn>request consent</dfn>, given an {{IdentityProvider}} |provider|:
         1. Let |accountState| be the result of running the [=compute account state=] algorithm
             given |provider| and |account|.
         1. If |accountState|'s {{AccountState/registration state}} is [=unregistered=] then run the
-            [=sign-up=] algorithm with |account|, |accountState|, |manifest|, and |provider|.
+            [=request consent to sign-up=] algorithm with |account|, |accountState|, |manifest|, and
+            |provider|.
         1. Otherwise, run the [=sign-in=] algorithm with |accountState|.
     1. If |accountState|'s {{AccountState/registration state}} is [=unregistered=] then return null.
     1. Let |token| be the result of running the [=create tokens=] algorithm with |accountState|,
         |account|'s {{account_json/id}}, and |provider|.
     1. Let |credential| be a new {{IdentityCredential}}.
     1. Set |credential|'s {{IdentityCredential/token}} to |token|.
-    1. return |credential|.
+    1. Return |credential|.
 </div>
 
 <div algorithm>
 To <dfn>compute account state</dfn> given an {{IdentityProvider}} |provider| and an
     [=Account JSON=] |account|, run the following steps:
     1. Let |idpURL| be |provider|'s {{IdentityProvider/configURL}}.
-    1. Let |idpOrigin| be the [=origin=] corresponding to |idpURL|. TODO: specify how to go from
-        string to [=origin=].
+    1. Let |idpOrigin| be the [=origin=] corresponding to |idpURL|.
     1. Let |rpOrigin| be [=this=]'s [=Document/origin=].
     1. Let |accountId| be |account|'s {{account_json/id}}.
     1. Let |triple| be (|rpOrigin|, |idpOrigin|, |accountId|).
@@ -1148,8 +1154,9 @@ To <dfn>fetch the accounts list</dfn> given a [=Manifest=] |manifest| and an {{I
 Issue: the [=fetch the accounts list=] algorithm needs to use [=fetch=] appropriately.
 
 <div algorithm>
-To <dfn>sign-up</dfn> the user with a given [=Account JSON=] |account|, an [=AccountState=]
-    |accountState|, a [=Manifest=] |manifest|, and an {{IdentityProvider}} |provider|:
+To <dfn>request consent to sign-up</dfn> the user with a given [=Account JSON=] |account|, an
+    [=AccountState=] |accountState|, a [=Manifest=] |manifest|, and an {{IdentityProvider}}
+    |provider|:
     1. Let |metadata| be the result of running the [=fetch the client metadata=]
         algorithm with |manifest| and |provider|.
     1. If |metadata|["{{client_metadata_endpoint_response/privacy_policy_url}}"] is defined and
@@ -1320,7 +1327,6 @@ When this method is invoked, the user agent MUST execute the following algorithm
   1. For each |request| in |logoutRequests|
     1. Let |rpOrigin| be [=this=]'s [=Document/origin=].
     1. Let |idpOrigin| be |request|'s {{IdentityCredentialLogoutRpsRequest/url}}'s [=origin=].
-        TODO: origin from string.
     1. Let |account| be |request|'s {{IdentityCredentialLogoutRpsRequest/accountId}}.
     1. Let |triple| be (|rpOrigin|, |idpOrigin|, |account|).
     1. If [=state machine map=][|triple|] does not exist, continue.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -429,7 +429,7 @@ provides the main security boundary on the web.
     * [[OIDC-Connect-Core]]
 
 : <dfn>site</dfn>
-:: A set of [=origins=] that are all [=same site=] with each other. Note that
+:: A set of [=origins=] that are all [=site/same site=] with each other. Note that
     there are problems ([[PSL-PROBLEMS]]) with using [=registrable domains=] as
     a logical boundary.
 
@@ -1186,10 +1186,10 @@ To <dfn noexport>fetch the client metadata</dfn> given a [=Manifest=] |manifest|
     1. Let the |clientMetadataEndpoint| url be the relative url
         |manifest|["{{Manifest/client_metadata_endpoint}}"] of |provider|'s
         {{IdentityProvider/configURL}}.
-    1. Let the |policies| be the result of fetching the |clientMetadataEndpoint| with the
+    1. Let the |clientMetadata| be the result of fetching the |clientMetadataEndpoint| with the
         [[#Sec-FedCM-CSRF|Sec-FedCM-CSRF]] header but without the [=Identity Provider=]'s cookies.  This request MUST NOT follow [[RFC9110#header.location|HTTP redirects]] and instead return
         null if there is any error. See also [[#idp-api-client-id-metadata-endpoint]].
-    1. Return |policies|.
+    1. Return |clientMetadata|.
 </div>
 
 <div algorithm>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1083,15 +1083,17 @@ requests.
 
            Note: At some point we would like to support choosing accounts from
            multiple [=Identity Provider=]s.
-      1. Let |provider| be |options|["{{CredentialRequestOptions/identity}}"]["{{IdentityCredentialRequestOptions/providers}}"][0].
-      1. Let |credential| be the result of running the [=potentially create IdentityCredential=]
-          algorithm with |provider|.
-      1. If |credential| is null, run {{setTimeout}} passing a [=task=] which throws a
-          {{NetworkError}}, after a timeout of 120 seconds.
+      1. Run {{setTimeout}} passing a [=task=] which throws a {{NetworkError}}, after a timeout of
+          120 seconds.
 
           Note: the purpose of having a timer here is to avoid leaking the reason causing this
           method to return null. If there was no such timer, the developer could easily infer
           whether the user has an account with the [=IDP=] or not, or whether the user closed the UI without providing consent to share the [=IDP=] account information with the [=RP=].
+      1. Let |provider| be |options|["{{CredentialRequestOptions/identity}}"]["{{IdentityCredentialRequestOptions/providers}}"][0].
+      1. Let |credential| be the result of running the [=potentially create IdentityCredential=]
+          algorithm with |provider|.
+      1. If |credential| is null, wait for the task that throws a {{NetworkError}}, otherwise return
+          |credential|.
 </div>
 
 <div algorithm>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -289,7 +289,7 @@ entries provided by the [=Identity Provider=].
 
 This specification defines a new {{IdentityCredential}} type and internal
 algorithms to allow the exchange of identity between [=IDP=]s and [=RP=]s.
-When it succeeds, it returns to the [=RP=] a signed [=id token=] which the
+When it succeeds, it returns to the [=RP=] a signed [=token=] which the
 [=RP=] can use to authenticate the user.
 
 <div class=example>
@@ -377,7 +377,7 @@ provides the main security boundary on the web.
 :: A use case specific API, as opposed to a [=low-level API=]. See also
     [high level vs low level](https://w3ctag.github.io/design-principles/#high-level-low-level).
 
-: <dfn>id token</dfn>
+: <dfn>token</dfn>
 :: TODO(goto): find existing definition.
 
 : <dfn>Identity Provider</dfn>
@@ -491,7 +491,7 @@ that they can use.
 │           │   │              │           │     ├────────────► *-+ client    │
 │           │   │              │           │     │                │ metadata  │
 │           │   │              │           │     │                │           │
-│           │   │              │           │     ├────────────► *-+ id_token  │
+│           │   │              │           │     ├────────────► *-+ token     │
 │           │   │              │           │     │                │           │
 │           │   │              │           │     │                │           │
 │           │   │              │           │     │                │           │
@@ -566,9 +566,9 @@ identity federation.
       |                               | "client_id, cookies, account"   |
       |                               |-------------------------------->|
       |                               |<--------------------------------| "{"
-      |                               |                                 |   "id_token: ...,"
+      |                               |                                 |   "token: ...,"
       |                               |                                 | "}"
-      |                "{ id_token }" |                                 |
+      |                "{ token }"    |                                 |
       |<------------------------------|                                 |
       |                               |                                 |
       |                               |                                 |
@@ -817,7 +817,7 @@ For example:
 ## ID Token ## {#idp-api-id-token-endpoint}
 <!-- ============================================================ -->
 
-The ID Token endpoint is responsible for [=minting=] a new [=id token=] for the user.
+The ID Token endpoint is responsible for [=minting=] a new [=token=] for the user.
 
 The ID Token endpoint is fetched
 (a) as a **POST** request,
@@ -858,8 +858,8 @@ account_id=123&client_id=client1234&nonce=Ct60bD&disclosure_text_shown=true
 The response is parsed as a JSON file expecting the following properties:
 
 <dl dfn-type="argument" dfn-for="id_token_endpoint_response">
-    :   <dfn>id_token</dfn>
-    ::  The resulting [=id token=].
+    :   <dfn>token</dfn>
+    ::  The resulting [=token=].
 </dl>
 
 For example:
@@ -867,7 +867,7 @@ For example:
 <div class=example>
 ```json
 {
-  "id_token" : "eyJC...J9.eyJzdWTE2...MjM5MDIyfQ.SflV_adQssw....5c"
+  "token" : "eyJC...J9.eyJzdWTE2...MjM5MDIyfQ.SflV_adQssw....5c"
 }
 ```
 </div>
@@ -917,13 +917,13 @@ the exchange of the user's identity.
 
 The Sign-up and Sign-in APIs are used by the [=Relying Party=]s to ask the browser
 to intermediate the relationship with the [=Identity Provider=] and the
-provisioning of an [=id token=].
+provisioning of a [=token=].
 
 NOTE: The [=Relying Party=] makes no delineation between Sign-up and Sign-in, but
 rather calls the same API indistinguishably.
 
 If all goes well, the [=Relying Party=] receives back an {{IdentityCredential}}
-which contains an [=id token=] in the form of a signed [[JWT]] which it can use to
+which contains a [=token=] in the form of a signed [[JWT]] which it can use to
 authenticate the user.
 
 <div class=example>
@@ -979,13 +979,14 @@ This specification introduces a new type of {{Credential}}, called an {{Identity
 <pre class="idl">
   [Exposed=Window, SecureContext]
   interface IdentityCredential : Credential {
-    readonly attribute USVString? idToken;
+    readonly attribute USVString? token;
   };
 </pre>
 
 <dl dfn-type="argument" dfn-for="IdentityCredential">
-    :   <dfn>idToken</dfn>
-    ::  The {{IdentityCredential/idToken}}'s attribute getter returns the value it is set to. It represents the minted ID token provided by the [=IDP=].
+    :   <dfn>token</dfn>
+    ::  The {{IdentityCredential/token}}'s attribute getter returns the value it is set to.
+        It represents the minted [=token=] provided by the [=IDP=].
 </dl>
 
 The main entrypoint in this specification is through the entrypoints exposed
@@ -1084,7 +1085,7 @@ When this method is invoked, the user agent MUST execute the following algorithm
   1. Request user consent by running the [=request consent=] algorithm with the |provider|.
   1. If {{StateMachine/Account State}} is [=unregistered=] then return null.
   1. Let |token| be the result of running the [=create tokens=] algorithm.
-  1. Set |credential|'s {{IdentityCredential/idToken}} to |token|.
+  1. Set |credential|'s {{IdentityCredential/token}} to |token|.
   1. return |credential|.
 
 To <dfn>request consent</dfn>:
@@ -1158,7 +1159,7 @@ To <dfn>create tokens</dfn>:
         1. Set |request|["nonce"] to |request|["{{IdentityProvider/nonce}}"].
     1. Let |tokens| be the result of making a POST request described in
         [[#idp-api-id-token-endpoint]].
-    1. Return |tokens|["id_token"].
+    1. Return |tokens|["token"].
 
 The <dfn>fetch the manifest</dfn> algorithm accepts an {{IdentityProvider}} |provider| and returns a [=Manifest=] object:
     1. In parallel, perform the following two steps:
@@ -1370,7 +1371,7 @@ expectations around their behavior.
     site can invoke the API, [=RP=]s cannot necessarily be trusted to limit the user information it
     collects or use that information in an acceptable way.
 1. [=Identity Provider=]s ([=IDP=]s) are third-party websites that are the target of a FedCM call to
-    attempt to fetch an [=id token=]. Usually,the [=IDP=] has a higher level of trust than the
+    attempt to fetch a [=token=]. Usually,the [=IDP=] has a higher level of trust than the
     [=RP=] since it already has the user’s personal information, but it is possible that the [=IDP=]
     might use the user’s information in non-approved ways. In addition, it is possible that the
     [=IDP=] specified in the API call may not be an [=IDP=] the user knows about. In this case, it
@@ -1732,7 +1733,7 @@ consent for a purpose different from that for which the information was collecte
 happens when [=IDP=]s misuse the the information collected to enable sign-in for other
 purposes.
 
-Existing federation protocols require that the [=IDP=] know which service is requesting an ID token
+Existing federation protocols require that the [=IDP=] know which service is requesting a [=token=]
 in order to allow identity federation. Identity providers can use this fact to build profiles of
 users across sites where the user has decided to use federation with the same account. This profile
 could be used, for example, to serve targeted advertisements to those users browsing on sites that

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1094,7 +1094,7 @@ To <dfn>request consent</dfn>, given an {{IdentityProvider}} |provider|:
     1. If |accountsList|'s size is 0, return null.
     1. If |accountsList|'s size is 1:
         1. Let |account| be |accountsList|[0].
-        1. Let |accountState| be the result of running the <a>compute account state</a> algorithm
+        1. Let |accountState| be the result of running the [=compute account state=] algorithm
             given |provider| and |account|.
         1. If |accountState|'s {{AccountState/registration state}} is [=unregistered=] then run the
             [=sign-up=] algorithm with |account|, |accountState|, |manifest|, and |provider|.
@@ -1104,7 +1104,7 @@ To <dfn>request consent</dfn>, given an {{IdentityProvider}} |provider|:
         1. Let |account| be the result of running the [=select an account=] from the
             |accountsList|.
         1. If |account| is null, return null.
-        1. Let |accountState| be the result of running the <a>compute account state</a> algorithm
+        1. Let |accountState| be the result of running the [=compute account state=] algorithm
             given |provider| and |account|.
         1. If |accountState|'s {{AccountState/registration state}} is [=unregistered=] then run the
             [=sign-up=] algorithm with |account|, |accountState|, |manifest|, and |provider|.
@@ -1119,7 +1119,7 @@ To <dfn>request consent</dfn>, given an {{IdentityProvider}} |provider|:
 
 <div algorithm>
 To <dfn>compute account state</dfn> given an {{IdentityProvider}} |provider| and an
-    <a>Account JSON</a> |account|, run the following steps:
+    [=Account JSON=] |account|, run the following steps:
     1. Let |idpURL| be |provider|'s {{IdentityProvider/configURL}}.
     1. Let |idpOrigin| be the [=origin=] corresponding to |idpURL|. TODO: specify how to go from
         string to [=origin=].
@@ -1148,7 +1148,7 @@ To <dfn>fetch the accounts list</dfn> given a [=Manifest=] |manifest| and an {{I
 Issue: the [=fetch the accounts list=] algorithm needs to use [=fetch=] appropriately.
 
 <div algorithm>
-To <dfn>sign-up</dfn> the user with a given [=Account JSON=] |account|, an [=Account State=]
+To <dfn>sign-up</dfn> the user with a given [=Account JSON=] |account|, an [=AccountState=]
     |accountState|, a [=Manifest=] |manifest|, and an {{IdentityProvider}} |provider|:
     1. Let |metadata| be the result of running the [=fetch the client metadata=]
         algorithm with |manifest| and |provider|.
@@ -1190,7 +1190,7 @@ To <dfn>select an account</dfn> given an |accountsList|:
 </div>
 
 <div algorithm>
-To <dfn>sign-in</dfn> the user with a given {{AccountState}} |accountState|:
+To <dfn>sign-in</dfn> the user with a given an [=AccountState=] |accountState|:
     1. Assert that |accountState|'s {{AccountState/registration state}} is [=registered=]
     1. Change |accountState|'s {{AccountState/allows logout}} from false to true.
 </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1080,11 +1080,36 @@ When this method is invoked, the user agent MUST execute the following algorithm
 To <dfn>request consent</dfn>, given an {{IdentityProvider}} |provider|:
     1. Let |manifest| be the result of running the [=fetch the manifest=]
         algorithm with |provider|.
-    1. Let |accounts list| be the result of running the
-        [=fetch the accounts list=] algorithm.
-    1. Let |account| be the result of running the [=select an account=] from the
-        |accounts list| algorithm.
-    1. If |account| is null, return.
+    1. Let |accountsList| be the result of running the
+        [=fetch the accounts list=] algorithm with |manifest| and |provider|.
+    1. If |accountsList|'s size is 0, return null.
+    1. If |accountsList|'s size is 1:
+        1. Let |account| be |accountsList|[0].
+        1. Let |accountState| be the result of running the <a>compute account state</a> algorithm
+            given |provider| and |account|.
+        1. If |accountState|'s {{AccountState/registration state}} is [=unregistered=] then run the
+            [=sign-up=] algorithm with |account|, |accountState|, |manifest|, and |provider|.
+        1. Otherwise, show a dialog to request user consent to sign in via |account|.
+        1. If the user consents, run the [=sign-in=] algorithm with |accountState|.
+    1. Otherwise:
+        1. Let |account| be the result of running the [=select an account=] from the
+            |accountsList|.
+        1. If |account| is null, return null.
+        1. Let |accountState| be the result of running the <a>compute account state</a> algorithm
+            given |provider| and |account|.
+        1. If |accountState|'s {{AccountState/registration state}} is [=unregistered=] then run the
+            [=sign-up=] algorithm with |account|, |accountState|, |manifest|, and |provider|.
+        1. Otherwise, run the [=sign-in=] algorithm with |accountState|.
+    1. If |accountState|'s {{AccountState/registration state}} is [=unregistered=] then return null.
+    1. Let |token| be the result of running the [=create tokens=] algorithm with |accountState|,
+        |account|'s {{account_json/id}}, and |provider|.
+    1. Set |credential|'s {{IdentityCredential/token}} to |token|.
+    1. return |credential|.
+</div>
+
+<div algorithm>
+To <dfn>compute account state</dfn> given an {{IdentityProvider}} |provider| and an
+    <a>Account JSON</a> |account|, run the following steps:
     1. Let |idpURL| be |provider|'s {{IdentityProvider/configURL}}.
     1. Let |idpOrigin| be the [=origin=] corresponding to |idpURL|. TODO: specify how to go from
         string to [=origin=].
@@ -1094,18 +1119,12 @@ To <dfn>request consent</dfn>, given an {{IdentityProvider}} |provider|:
     1. If [=state machine map=][|triple|] does not exist, set [=state machine map=][|triple|] to a
         new [=AccountState=].
     1. Let |accountState| be [=state machine map=][|triple|].
-    1. If |accountState|'s {{AccountState/registration state}} is [=unregistered=] then run the
-        [=sign-up=] algorithm for |triple|.
-    1. Otherwise, run the [=sign-in=] algorithm for |triple|.
-    1. If |accountState|'s {{AccountState/registration state}} is [=unregistered=] then return null.
-    1. Let |token| be the result of running the [=create tokens=] algorithm with |accountState|,
-        |accountId|, and |provider|.
-    1. Set |credential|'s {{IdentityCredential/token}} to |token|.
-    1. return |credential|.
+    1. Return |accountState|.
 </div>
 
 <div algorithm>
-To <dfn>fetch the accounts list</dfn>:
+To <dfn>fetch the accounts list</dfn> given a [=Manifest=] |manifest| and an {{IdentityProvider}}
+    |provider|:
     1. Let the |accounts_endpoint| url be the relative url
         |manifest|["{{Manifest/accounts_endpoint}}"] of
         |provider|["{{IdentityProvider/configURL}}"]
@@ -1119,9 +1138,10 @@ To <dfn>fetch the accounts list</dfn>:
 Issue: the [=fetch the accounts list=] algorithm needs to use [=fetch=] appropriately.
 
 <div algorithm>
-To <dfn>sign-up</dfn> the user with a given |triple| of (|rpOrigin|, |idpOrigin|, |account|):
+To <dfn>sign-up</dfn> the user with a given [=Account JSON=] |account|, an [=Account State=]
+    |accountState|, a [=Manifest=] |manifest|, and an {{IdentityProvider}} |provider|:
     1. Let |metadata| be the result of running the [=fetch the client metadata=]
-        algorithm.
+        algorithm with |manifest| and |provider|.
     1. If |metadata|["{{client_metadata_endpoint_response/privacy_policy_url}}"] is defined and
         the provider["{{IdentityProvider/clientId}}"] is not in the list of |account|["{{account_json/approved_clients}}"]
         then display the |metadata|["{{client_metadata_endpoint_response/privacy_policy_url}}"] link.
@@ -1131,14 +1151,14 @@ To <dfn>sign-up</dfn> the user with a given |triple| of (|rpOrigin|, |idpOrigin|
     1. Prompt the user to gather explicit intent to create an account. The user agent MAY use the
         [=Branding JSON=] to inform the style choices of its UI.
     1. If the user does not provide consent, return.
-    1. Let |accountState| be [=state machine map=][|triple|].
     1. Change |accountState|'s {{AccountState/registration state}} from [=unregistered=] to
         [=registered=].
     1. Change |accountState|'s {{AccountState/allows logout}} from false to true.
 </div>
 
 <div algorithm>
-To <dfn noexport>fetch the client metadata</dfn>:
+To <dfn noexport>fetch the client metadata</dfn> given a [=Manifest=] |manifest| and an
+    {{IdentityProvider}} |provider|, run the following steps:
     1. Let the |client_metadata_endpoint| url be the relative url
         |manifest|["{{Manifest/client_metadata_endpoint}}"] of
         |provider|["{{IdentityProvider/configURL}}"]
@@ -1151,18 +1171,16 @@ To <dfn noexport>fetch the client metadata</dfn>:
 </div>
 
 <div algorithm>
-To <dfn>select an account</dfn> from the accounts list:
-    1. If |accounts list|'s [=list/size=] is 1:
-        1. Let |account| be |accounts list|[0] and return |account|
-    1. Display an account chooser
+To <dfn>select an account</dfn> given an |accountsList|:
+    1. Assert |accountsList|'s [=list/size=] is greater than 1.
+    1. Display an account chooser displaying the options from |accountsList|.
     1. Let |account| be the {{account_json/id}} of the account that the user
         manually selects from the accounts chooser, or null if no account is selected.
     1. Return |account|
 </div>
 
 <div algorithm>
-To <dfn>sign-in</dfn> the user with a given |triple| of (|rpOrigin|, |idpOrigin|, |account|):
-    1. Let |accountState| be [=state machine map=][|triple|].
+To <dfn>sign-in</dfn> the user with a given {{AccountState}} |accountState|:
     1. Assert that |accountState|'s {{AccountState/registration state}} is [=registered=]
     1. Change |accountState|'s {{AccountState/allows logout}} from false to true.
 </div>

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1087,11 +1087,11 @@ requests.
            Note: At some point we would like to support choosing accounts from
            multiple [=Identity Provider=]s.
       1. Let |provider| be |options|["{{CredentialRequestOptions/identity}}"]["{{IdentityCredentialRequestOptions/providers}}"][0].
-      1. Return the [=request consent=] algorithm with |provider|.
+      1. Return the [=potentially create IdentityCredential=] algorithm with |provider|.
 </div>
 
 <div algorithm>
-To <dfn>request consent</dfn>, given an {{IdentityProvider}} |provider|:
+To <dfn>potentially create IdentityCredential</dfn>, given an {{IdentityProvider}} |provider|:
     1. Let |manifest| be the result of running the [=fetch the manifest=]
         algorithm with |provider|.
     1. Let |accountsList| be the result of running the

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1087,7 +1087,7 @@ requests.
       1. Let |credential| be the result of running the [=potentially create IdentityCredential=]
           algorithm with |provider|.
       1. If |credential| is null, run {{setTimeout}} passing a [=task=] which throws a
-          {{NetworkError}}, after a timeout of 3 seconds.
+          {{NetworkError}}, after a timeout of 120 seconds.
 
           Note: the purpose of having a timer here is to avoid leaking the reason causing this
           method to return null. If there was no such timer, the developer could easily infer


### PR DESCRIPTION
This PR defines the State Machine a bit more precisely by noting it is based on a map for the RP, IDP, and account id. Some algorithms are improved to make more sense, and some duplicate definitions are removed. Also fixes https://github.com/fedidcg/FedCM/issues/298, https://github.com/fedidcg/FedCM/issues/297, https://github.com/fedidcg/FedCM/issues/296, and part of https://github.com/fedidcg/FedCM/issues/295.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/npm1/FedCM/pull/304.html" title="Last updated on Jul 13, 2022, 7:50 PM UTC (3c02878)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/fedidcg/FedCM/304/cd9737d...npm1:3c02878.html" title="Last updated on Jul 13, 2022, 7:50 PM UTC (3c02878)">Diff</a>