### PR TITLE
Fixes to nonce

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -110,7 +110,11 @@ The following is an example of a website allowing a user to login with
 `idp.example`.
 
 ```js
+let nonce;
 async function login() {
+  // Assume we have a method returning a random number. Store the value in a variable which can
+  // later be used to check against the value in the token returned.
+  nonce = random();
   // Prompt the user to select an account from the IDP to use for
   // federated login within the RP. If resolved successfully, the Promise
   // returns an IdentityCredential object from which the `token` can be
@@ -121,8 +125,7 @@ async function login() {
       providers: [{
         configURL: "https://idp.example/fedcm.json",
         clientId: "123",
-        nonce: random() // assume we have a method returning a random number
-      }]
+        nonce: nonce
     }
   });
 }
@@ -189,6 +192,7 @@ the user has consented to the authentication. The returned tokens can then be
 used as needed.
 
 ```js
+let nonce = random()
 // If successful, returns a Promise containing an IdentityCredential |cred| object.
 // The token for logging in is in cred.token.
 const cred = await navigator.credentials.get({
@@ -197,7 +201,7 @@ const cred = await navigator.credentials.get({
     providers: [{
       configURL: "https://idp.example/fedcm.json",
       clientId: "123",
-      nonce: random()
+      nonce: nonce
     }]
   }
 });
@@ -272,8 +276,9 @@ const cred = await navigator.credentials.get({
     }]
   }
 });
+let nonce = random()
 const tokens = await cred.login({
-  nonce: random(),
+  nonce: nonce,
   tokens: ["access", "refresh", "id"],
   scopes: ["calendar.read", "profile"]
 });

--- a/explainer.md
+++ b/explainer.md
@@ -192,7 +192,7 @@ the user has consented to the authentication. The returned tokens can then be
 used as needed.
 
 ```js
-let nonce = random()
+let nonce = random();
 // If successful, returns a Promise containing an IdentityCredential |cred| object.
 // The token for logging in is in cred.token.
 const cred = await navigator.credentials.get({
@@ -276,7 +276,7 @@ const cred = await navigator.credentials.get({
     }]
   }
 });
-let nonce = random()
+let nonce = random();
 const tokens = await cred.login({
   nonce: nonce,
   tokens: ["access", "refresh", "id"],

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -305,7 +305,11 @@ could be implemented.
   <button onclick="login()">Login with idp.example</button>
 
   <script>
+  let nonce;
   async function login() {
+    // Assume we have a method returning a random number. Store the value in a variable which can
+    // later be used to check against the value in the token returned.
+    nonce = random();
     // Prompt the user to select an account from the IDP to use for
     // federated login within the RP. If resolved successfully, the Promise
     // returns an IdentityCredential object from which the `token` can be
@@ -316,7 +320,7 @@ could be implemented.
         providers: [{
           configURL: "https://idp.example/manifest.json",
           clientId: "123",
-          nonce: random() // assume we have a method returning a random number
+          nonce: nonce
         }]
       }
     });


### PR DESCRIPTION
Store the nonce and make it clearer that it is to be checked against the value received in the IDP token.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/npm1/FedCM/pull/308.html" title="Last updated on Jul 5, 2022, 7:31 PM UTC (2d0206d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/fedidcg/FedCM/308/97690b6...npm1:2d0206d.html" title="Last updated on Jul 5, 2022, 7:31 PM UTC (2d0206d)">Diff</a>