### PR TITLE
Refer to the right "Mozilla Persona"

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -624,7 +624,7 @@ place in
 
 By descending order of proximity:
 
-* [Mozilla Personas](https://github.com/mozilla/persona)
+* [Mozilla Persona](https://github.com/mozilla/persona)
 * [Web Login](https://github.com/junosuarez/web-login)
 * [OpenYOLO](https://github.com/openid/OpenYOLO-Web)
 * [Basic Auth](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication)


### PR DESCRIPTION
Mozilla Personas were theme add-ons for Firefox (see https://blog.mozilla.org/addons/personas-are-now-firefox-themes/) whereas Mozilla Persona was the identity system that started its life as BrowserID.