### PR TITLE
Remove UI claim

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1438,18 +1438,16 @@ The FedCM API introduces new (trusted) user agent UI, and the user agent may cho
 entirely on top of the page's contents, if anything because the page was the one responsible for
 this UI. This introduces a potential concern of a malicious site to try to replicate the FedCM UI,
 gain the user's trust that the user is interacting with a trusted browser surface, and gather
-information from the user that they would only give to the browser rather than the site
-(e.g. usernames/passwords of **another** site). This is not possible because the FedCM UI uses the
-metadata about the user accounts of the [=IDP=], which the website doesn't have access. If this is
-a malicious site, it would not know the user accounts, otherwise the user is already compromised.
-In addition, the FedCM UI is deliberately constructed to not prompt the user to provide additional
-information, such as username or password. Thus, an attacker trying to impersonate the browser
-using exclusively UI that is accessible to the content area (e.g. iframes) to attempt to retrieve
-sensitive information from the user would be noticeably different from the FedCM UI. Finally,
-because the FedCM UI can only be queried from the top-level frame (or potentially from an iframe
-with explicit permission from the top-level frame), the priviledged UI surface is only shown when
-the top-level frame wants it so. A sneaky iframe cannot force the FedCM UI to occlude important
-content from the main page.
+information from the user that they would only give to the browser rather than the site (e.g.
+usernames/passwords of **another** site). This is not possible because the FedCM UI uses the
+metadata about the user accounts of the [=IDP=], which the website doesn't have access. If this is a
+malicious site, it would not know the user accounts, otherwise the user is already compromised.
+Thus, an attacker trying to impersonate the browser using exclusively UI that is accessible to the
+content area (e.g. iframes) to attempt to retrieve sensitive information from the user would be
+noticeably different from the FedCM UI. Finally, because the FedCM UI can only be queried from the
+top-level frame (or potentially from an iframe with explicit permission from the top-level frame),
+the priviledged UI surface is only shown when the top-level frame wants it so. A sneaky iframe
+cannot force the FedCM UI to occlude important content from the main page.
 
 <!-- ============================================================ -->
 # Privacy # {#privacy}


### PR DESCRIPTION
We should generally avoid user agent UI claims in the spec, as this is generally left for a user agent to decide freely. In addition, this particular claim may not be true in the future if we enable a login flow from the FedCM API. Fixes https://github.com/fedidcg/FedCM/issues/323


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/npm1/FedCM/pull/337.html" title="Last updated on Aug 24, 2022, 4:34 PM UTC (2953640)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/fedidcg/FedCM/337/3d034dc...npm1:2953640.html" title="Last updated on Aug 24, 2022, 4:34 PM UTC (2953640)">Diff</a>