### PR TITLE
Add fetch calls

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1186,10 +1186,21 @@ To <dfn>fetch the accounts list</dfn> given a [=Manifest=] |manifest| and an {{I
         |manifest|[{{Manifest/accounts_endpoint}}] (the relative URL) and |provider|'s
         {{IdentityProviderConfig/configURL}} (the base URL).
     1. If |accountsUrl| is failure, return an empty list.
-    1. Let |request| be a new <a spec=fetch for=/>request</a> whose [=request/url=] is
-        |accountsUrl| and [=request/redirect mode=] set to "error".
-    1. TODO: set other fields of the request, including the [[#Sec-FedCM-CSRF|Sec-FedCM-CSRF]]
-        header or equivalent, as well as using [=Identity Provider=]'s cookies.
+    1. If |accountsUrl| is not [=same origin=] with |provider|'s
+        {{IdentityProviderConfig/configURL}}, return an empty list.
+    1. If |accountsUrl| is not a [=potentially trustworthy URL=], return an empty list.
+    1. Let |request| be a new <a spec=fetch for=/>request</a> with the following properties:
+        1. [=request/url=] set to |accountsUrl|
+        1. [=request/redirect mode=] set to "error"
+        1. [=request/client=] set to null
+        1. [=request/window=] set to "no-window"
+        1. [=request/service-workers mode=] set to "none"
+        1. [=request/destination=] set to "identity"
+        1. [=request/origin=] set to a unique [=opaque origin=]
+        1. [=request/header list=] set to a [=list=] containing a single [=header=] with
+            [=header/name=] set to "Accept" and [=header/value=] set to "JSON"
+        1. [=request/referrer policy=] set to "no-referrer"
+        1. [=request/credentials mode=] set to "include"
 
         Issue: The credentialed fetch in this algorithm can lead to a timing attack that leaks the user's identities before the user consents. This is an active area of investigation that is being explored [here](https://github.com/fedidcg/FedCM/issues/230#issuecomment-1089040953).
     1. Let |accountsList| be an empty list.
@@ -1255,10 +1266,21 @@ To <dfn noexport>fetch the client metadata</dfn> given a [=Manifest=] |manifest|
         |manifest|["{{Manifest/client_metadata_endpoint}}"] (the relative URL) and |provider|'s
         {{IdentityProviderConfig/configURL}} (the base URL).
     1. If |clientMetadataUrl| is failure, return null.
-    1. Let |request| be a new <a spec=fetch for=/>request</a> whose [=request/url=] is
-        |clientMetadataUrl| and [=request/redirect mode=] set to "error".
-    1. TODO: set other fields of the request, including the [[#Sec-FedCM-CSRF|Sec-FedCM-CSRF]]
-        header or equivalent.
+    1. If |clientMetadataUrl| is not a [=potentially trustworthy URL=], return null.
+    1. If |clientMetadataUrl| is not [=same origin=] with |provider|'s
+        {{IdentityProviderConfig/configURL}}, return null.
+    1. Let |request| be a new <a spec=fetch for=/>request</a> with the following properties:
+        1. [=request/url=] set to |clientMetadataUrl|
+        1. [=request/redirect mode=] set to "error"
+        1. [=request/client=] set to null
+        1. [=request/window=] set to "no-window"
+        1. [=request/service-workers mode=] set to "none"
+        1. [=request/destination=] set to "identity"
+        1. [=request/origin=] set to a unique [=opaque origin=]
+        1. [=request/header list=] set to a [=list=] containing a single [=header=] with
+            [=header/name=] set to "Accept" and [=header/value=] set to "JSON"
+        1. [=request/referrer=] set to [=RP=]'s URL (TODO).
+        1. [=request/credentials mode=] set to "omit"
     1. Let |clientMetadata| be a new [=ordered map=].
     1. [=Fetch=] |request| with <a spec=fetch>processResponseConsumeBody</a> set to the following
         steps given a <a spec=fetch for=/>response</a> |response|:
@@ -1300,16 +1322,28 @@ To <dfn>create tokens</dfn> given an [=AccountState=] |accountState|, a {{USVStr
     1. Let |tokenUrl| be the result of running [=url parser=] given
         |manifest|[{{Manifest/id_token_endpoint}}] (the relative URL) and |provider|'s
         {{IdentityProviderConfig/configURL}} (the base URL).
-    1. If |tokenUrl| is failure, return an empty list.
+    1. If |tokenUrl| is failure, return null.
+    1. If |tokenUrl| is not [=same origin=] with |provider|'s {{IdentityProviderConfig/configURL}},
+        return null.
+    1. If |tokenUrl| is not a [=potentially trustworthy URL=], return null.
     1. Let |requestBody| be a new object constructed as follows (TODO: what is the correct type):
         1. Set |requestBody|["account_id"] to |accountId|.
         1. Set |requestBody|["client_id"] to |provider|'s {{IdentityProviderConfig/clientId}}.
         1. Set |requestBody|["nonce"] to |provider|'s {{IdentityProviderConfig/nonce}}.
-    1. Let |request| be a new <a spec=fetch for=/>request</a> whose [=request/url=] is
-        |tokenUrl|, [=request/redirect mode=] set to "error", [=request/mode=] set to `POST`, and
-        [=request/body=] set to |requestBody|.
-    1. TODO: set other fields of the request, including the [[#Sec-FedCM-CSRF|Sec-FedCM-CSRF]]
-        header or equivalent, as well as using [=Identity Provider=]'s cookies.
+    1. Let |request| be a new <a spec=fetch for=/>request</a> with the following properties:
+        1. [=request/url=] set to |tokenUrl|
+        1. [=request/mode=] set to "POST"
+        1. [=request/body=] set to |requestBody|
+        1. [=request/redirect mode=] set to "error"
+        1. [=request/client=] set to null
+        1. [=request/window=] set to "no-window"
+        1. [=request/service-workers mode=] set to "none"
+        1. [=request/destination=] set to "identity"
+        1. [=request/origin=] set to a unique [=opaque origin=]
+        1. [=request/header list=] set to a [=list=] containing a single [=header=] with
+            [=header/name=] set to "Accept" and [=header/value=] set to "JSON"
+        1. [=request/referrer=] set to [=RP=]'s URL (TODO).
+        1. [=request/credentials mode=] set to "include"
     1. Let |token| be null.
     1. [=Fetch=] |request| with <a spec=fetch>processResponseConsumeBody</a> set to the following
         steps given a <a spec=fetch for=/>response</a> |response|:
@@ -1351,8 +1385,19 @@ whether the manifest is included in the manifest list:
     1. Set |rootUrl|'s [=url/scheme=] to |configUrl|'s [=url/scheme=].
     1. Set |rootUrl|'s [=url/host=] to |configUrl|'s [=url/host=]'s [=host/registrable domain=].
     1. Set |rootUrl|'s [=url/path=] to the <a>list</a> «".well-known", "web-identity"».
-    1. Let |request| be a new <a spec=fetch for=/>request</a> whose [=request/url=] is |rootUrl| and
-        [=request/redirect mode=] set to "error". TODO: what other fields need to be set?
+    1. If |rootUrl| is not a [=potentially trustworthy URL=], return false.
+    1. Let |request| be a new <a spec=fetch for=/>request</a> with the following properties:
+        1. [=request/url=] set to |rootUrl|
+        1. [=request/redirect mode=] set to "error"
+        1. [=request/client=] set to null
+        1. [=request/window=] set to "no-window"
+        1. [=request/service-workers mode=] set to "none"
+        1. [=request/destination=] set to "identity"
+        1. [=request/origin=] set to a unique [=opaque origin=]
+        1. [=request/header list=] set to a [=list=] containing a single [=header=] with
+            [=header/name=] set to "Accept" and [=header/value=] set to "JSON"
+        1. [=request/referrer policy=] set to "no-referrer"
+        1. [=request/credentials mode=] set to "omit"
     1. Let |check| be false.
     1. [=Fetch=] |request| with <a spec=fetch>processResponseConsumeBody</a> set to the following
         steps given a <a spec=fetch for=/>response</a> |response|:
@@ -1379,14 +1424,23 @@ whether the manifest is included in the manifest list:
 The <dfn>fetch the internal manifest</dfn> algorithm accepts an {{IdentityProviderConfig}} |provider| and returns a [=Manifest=] or null if there is some failure fetching or parsing the manifest:
     1. Run a [[!CSP]] check with a [[CSP#directive-connect-src|connect-src]]
         directive on the URL passed as |provider|'s {{IdentityProviderConfig/configURL}}
-        and return if the check fails. TODO: Add parameters to integrate this check into fetch.
+        and return if the check fails.
     1. Let |url| be |provider|'s {{IdentityProviderConfig/configURL}}.
+    1. If |url| is not a [=potentially trustworthy URL=], return null.
+    1. Let |request| be a new <a spec=fetch for=/>request</a> with the following properties:
+        1. [=request/url=] set to |url|
+        1. [=request/redirect mode=] set to "error"
+        1. [=request/client=] set to null
+        1. [=request/window=] set to "no-window"
+        1. [=request/service-workers mode=] set to "none"
+        1. [=request/destination=] set to "identity"
+        1. [=request/origin=] set to a unique [=opaque origin=]
+        1. [=request/header list=] set to a [=list=] containing a single [=header=] with
+            [=header/name=] set to "Accept" and [=header/value=] set to "JSON"
+        1. [=request/referrer policy=] set to "no-referrer"
+        1. [=request/credentials mode=] set to "omit"
     1. Let |request| be a new <a spec=fetch for=/>request</a> whose [=request/url=] is |url| and
         [=request/redirect mode=] set to "error".
-    1. TODO: set other fields of the request, including the [[#Sec-FedCM-CSRF|Sec-FedCM-CSRF]]
-        header or equivalent.
-
-        Issue: it is unclear if the [[#Sec-FedCM-CSRF|Sec-FedCM-CSRF]] header is [needed](https://github.com/fedidcg/FedCM/issues/267) on the manifest fetch.
     1. Let |manifest| be null.
     1. [=Fetch=] |request| with <a spec=fetch>processResponseConsumeBody</a> set to the following
         steps given a <a spec=fetch for=/>response</a> |response|:

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1348,14 +1348,13 @@ To <dfn>create tokens</dfn> given an [=AccountState=] |accountState|, a {{USVStr
     1. If |idTokenUrl| is failure, return null.
     1. If |idTokenUrl| is not [=same origin=] with |configUrl|, return null.
     1. If |idTokenUrl| is not a [=potentially trustworthy URL=], return null.
-    1. Let |requestBody| be a new object constructed as follows (TODO: what is the correct type):
-        1. Set |requestBody|["account_id"] to |accountId|.
-        1. Set |requestBody|["client_id"] to |provider|'s {{IdentityProviderConfig/clientId}}.
-        1. Set |requestBody|["nonce"] to |provider|'s {{IdentityProviderConfig/nonce}}.
+    1. Let |requestBody| be a [=string=] resulting in concatenating "client_id=",
+        |provider|'s {{IdentityProviderConfig/clientId}}, "&nonce=",
+        |provider|'s {{IdentityProviderConfig/nonce}}, "&account_id=", and |accountId|.
     1. Let |request| be a new <a spec=fetch for=/>request</a> with the following properties:
         1. [=request/url=] set to |idTokenUrl|
         1. [=request/mode=] set to "POST"
-        1. [=request/body=] set to |requestBody|
+        1. [=request/body=] set to the [=UTF-8 encode=] of |requestBody|
         1. [=request/redirect mode=] set to "error"
         1. [=request/client=] set to null
         1. [=request/window=] set to "no-window"
@@ -1459,7 +1458,6 @@ The <dfn>fetch the internal manifest</dfn> algorithm accepts an {{IdentityProvid
         steps given a <a spec=fetch for=/>response</a> |response|:
         1. Let |json| be the result of [=extract the JSON fetch response=] from |response|.
         1. If |json| is null, return.
-        1. If |json| is a parsing exception, or if |json| is not an [=ordered map=], return.
         1. If |json|["accounts_endpoint"] does not exist, or if it is not a [=string=], return.
         1. If |json|["client_metadata_endpoint"] does not exist, or if it is not a [=string=],
             return.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1168,8 +1168,9 @@ To <dfn>potentially create IdentityCredential</dfn>, given an {{IdentityProvider
 <div algorithm>
 To <dfn>compute account state</dfn> given an {{IdentityProviderConfig}} |provider| and an
     [=Account JSON=] |account|, run the following steps:
-    1. Let |idpURL| be |provider|'s {{IdentityProviderConfig/configURL}}.
-    1. Let |idpOrigin| be the [=origin=] corresponding to |idpURL|.
+    1. Let |configUrl| be the result of running [=url parser=] with |provider|'s
+        {{IdentityProviderConfig/configURL}}.
+    1. Let |idpOrigin| be the [=origin=] corresponding to |configUrl|.
     1. Let |rpOrigin| be [=this=]'s [=Document/origin=].
     1. Let |accountId| be |account|'s {{account_json/id}}.
     1. Let |triple| be (|rpOrigin|, |idpOrigin|, |accountId|).
@@ -1182,12 +1183,19 @@ To <dfn>compute account state</dfn> given an {{IdentityProviderConfig}} |provide
 <div algorithm>
 To <dfn>fetch the accounts list</dfn> given a [=Manifest=] |manifest| and an {{IdentityProviderConfig}}
     |provider|:
+    1. Let |configUrl| be the result of running [=url parser=] with |provider|'s
+        {{IdentityProviderConfig/configURL}}.
     1. Let |accountsUrl| be the result of running [=url parser=] given
-        |manifest|[{{Manifest/accounts_endpoint}}] (the relative URL) and |provider|'s
-        {{IdentityProviderConfig/configURL}} (the base URL).
+        |manifest|["{{Manifest/accounts_endpoint}}"].
+    1. If |accountsUrl| is failure, let |accountsUrl| be the result of running
+        [=url parser=] given |manifest|["{{Manifest/accounts_endpoint}}"] (the relative URL) and
+        |configUrl| (the base URL).
+    
+    Note: This means the we allow passing the accounts endpoint as either an absolute or relative
+        URL.
+
     1. If |accountsUrl| is failure, return an empty list.
-    1. If |accountsUrl| is not [=same origin=] with |provider|'s
-        {{IdentityProviderConfig/configURL}}, return an empty list.
+    1. If |accountsUrl| is not [=same origin=] with |configUrl|, return an empty list.
     1. If |accountsUrl| is not a [=potentially trustworthy URL=], return an empty list.
     1. Let |request| be a new <a spec=fetch for=/>request</a> with the following properties:
         1. [=request/url=] set to |accountsUrl|
@@ -1195,7 +1203,7 @@ To <dfn>fetch the accounts list</dfn> given a [=Manifest=] |manifest| and an {{I
         1. [=request/client=] set to null
         1. [=request/window=] set to "no-window"
         1. [=request/service-workers mode=] set to "none"
-        1. [=request/destination=] set to "identity"
+        1. [=request/destination=] set to "web-identity"
         1. [=request/origin=] set to a unique [=opaque origin=]
         1. [=request/header list=] set to a [=list=] containing a single [=header=] with
             [=header/name=] set to "Accept" and [=header/value=] set to "JSON"
@@ -1206,14 +1214,8 @@ To <dfn>fetch the accounts list</dfn> given a [=Manifest=] |manifest| and an {{I
     1. Let |accountsList| be an empty list.
     1. [=Fetch=] |request| with <a spec=fetch>processResponseConsumeBody</a> set to the following
         steps given a <a spec=fetch for=/>response</a> |response|:
-        1. If |response| is a [=network error=] or its [=response/status=] is not an [=ok status=],
-            return.
-        1. Let |mimeType| be the result of <a>extracting a MIME TYPE</a> from |response|'s
-            <a for=response>header list</a>.
-        1. If |mimeType| is failure or is not a [=JSON MIME Type=], return.
-        1. Let |json| be the result of [=parse JSON bytes to an Infra value=] passing |response|'s
-            [=response/body=].
-        1. If |json| is a parsing exception, or if |json| is not an [=ordered map=], return.
+        1. Let |json| be the result of [=extract the JSON fetch response=] from |response|.
+        1. If |json| is null, return.
         1. If |json|["accounts"] does not exist, or if it is not a [=list=], return.
         1. Let |potentialAccountsList| be an empty list.
         1. For each |account| in |json|["accounts"]:
@@ -1234,6 +1236,19 @@ To <dfn>fetch the accounts list</dfn> given a [=Manifest=] |manifest| and an {{I
     1. Return |accountsList|.
 
         Issue: We should validate the accounts list returned here for repeated ids, as described [here](https://github.com/fedidcg/FedCM/issues/336).
+</div>
+
+<div algorithm>
+To <dfn>extract the JSON fetch response</dfn> given a <a spec=fetch for=/>response</a> |response|:
+    1. If |response| is a [=network error=] or its [=response/status=] is not an [=ok status=],
+        return null.
+    1. Let |mimeType| be the result of <a>extracting a MIME TYPE</a> from |response|'s
+        <a for=response>header list</a>.
+    1. If |mimeType| is failure or is not a [=JSON MIME Type=], return null.
+    1. Let |json| be the result of [=parse JSON bytes to an Infra value=] passing |response|'s
+        [=response/body=].
+    1. If |json| is a parsing exception, or if |json| is not an [=ordered map=], return null.
+    1. Return |json|.
 </div>
 
 <div algorithm>
@@ -1262,20 +1277,26 @@ To <dfn>request consent to sign-up</dfn> the user with a given [=Account JSON=] 
 <div algorithm>
 To <dfn noexport>fetch the client metadata</dfn> given a [=Manifest=] |manifest| and an
     {{IdentityProviderConfig}} |provider|, run the following steps:
+    1. Let |configUrl| be the result of running [=url parser=] with |provider|'s
+        {{IdentityProviderConfig/configURL}}.
     1. Let |clientMetadataUrl| be the result of running [=url parser=] given
-        |manifest|["{{Manifest/client_metadata_endpoint}}"] (the relative URL) and |provider|'s
-        {{IdentityProviderConfig/configURL}} (the base URL).
+        |manifest|["{{Manifest/client_metadata_endpoint}}"].
+    1. If |clientMetadataUrl| is failure, let |clientMetadataUrl| be the result of running
+        [=url parser=] given |manifest|["{{Manifest/client_metadata_endpoint}}"] (the relative URL) and |configUrl| (the base URL).
+    
+    Note: This means the we allow passing the client metadata endpoint as either an absolute or
+        relative URL.
+
     1. If |clientMetadataUrl| is failure, return null.
     1. If |clientMetadataUrl| is not a [=potentially trustworthy URL=], return null.
-    1. If |clientMetadataUrl| is not [=same origin=] with |provider|'s
-        {{IdentityProviderConfig/configURL}}, return null.
+    1. If |clientMetadataUrl| is not [=same origin=] with |configUrl|, return null.
     1. Let |request| be a new <a spec=fetch for=/>request</a> with the following properties:
         1. [=request/url=] set to |clientMetadataUrl|
         1. [=request/redirect mode=] set to "error"
         1. [=request/client=] set to null
         1. [=request/window=] set to "no-window"
         1. [=request/service-workers mode=] set to "none"
-        1. [=request/destination=] set to "identity"
+        1. [=request/destination=] set to "web-identity"
         1. [=request/origin=] set to a unique [=opaque origin=]
         1. [=request/header list=] set to a [=list=] containing a single [=header=] with
             [=header/name=] set to "Accept" and [=header/value=] set to "JSON"
@@ -1284,14 +1305,8 @@ To <dfn noexport>fetch the client metadata</dfn> given a [=Manifest=] |manifest|
     1. Let |clientMetadata| be a new [=ordered map=].
     1. [=Fetch=] |request| with <a spec=fetch>processResponseConsumeBody</a> set to the following
         steps given a <a spec=fetch for=/>response</a> |response|:
-        1. If |response| is a [=network error=] or its [=response/status=] is not an [=ok status=],
-            return.
-        1. Let |mimeType| be the result of <a>extracting a MIME TYPE</a> from |response|'s
-            <a for=response>header list</a>.
-        1. If |mimeType| is failure or is not a [=JSON MIME Type=], return.
-        1. Let |json| be the result of [=parse JSON bytes to an Infra value=] passing |response|'s
-            [=response/body=].
-        1. If |json| is a parsing exception, or if |json| is not an [=ordered map=], return.
+        1. Let |json| be the result of [=extract the JSON fetch response=] from |response|.
+        1. If |json| is null, return.
         1. If |json|["privacy_policy_url"] exists and is a [=string=], set
             |clientMetadata|["privacy_policy_url"] to |json|["privacy_policy_url"].
         1. If |json|["terms_of_service_url"] exists and is a [=string=], set
@@ -1319,42 +1334,44 @@ To <dfn>create tokens</dfn> given an [=AccountState=] |accountState|, a {{USVStr
     an {{IdentityProviderConfig}} |provider|, and a [=Manifest=] |manifest|:
     1. Assert |accountState|'s {{AccountState/registration state}} is [=registered=].
     1. Assert |accountState|'s {{AccountState/allows logout}} is true.
-    1. Let |tokenUrl| be the result of running [=url parser=] given
-        |manifest|[{{Manifest/id_token_endpoint}}] (the relative URL) and |provider|'s
-        {{IdentityProviderConfig/configURL}} (the base URL).
-    1. If |tokenUrl| is failure, return null.
-    1. If |tokenUrl| is not [=same origin=] with |provider|'s {{IdentityProviderConfig/configURL}},
-        return null.
-    1. If |tokenUrl| is not a [=potentially trustworthy URL=], return null.
+    1. Let |configUrl| be the result of running [=url parser=] with |provider|'s
+        {{IdentityProviderConfig/configURL}}.
+    1. Let |idTokenUrl| be the result of running [=url parser=] given
+        |manifest|["{{Manifest/id_token_endpoint}}"].
+    1. If |idTokenUrl| is failure, let |idTokenUrl| be the result of running
+        [=url parser=] given |manifest|["{{Manifest/id_token_endpoint}}"] (the relative URL) and
+        |configUrl| (the base URL).
+    
+    Note: This means the we allow passing the id token endpoint as either an absolute or relative
+        URL.
+
+    1. If |idTokenUrl| is failure, return null.
+    1. If |idTokenUrl| is not [=same origin=] with |configUrl|, return null.
+    1. If |idTokenUrl| is not a [=potentially trustworthy URL=], return null.
     1. Let |requestBody| be a new object constructed as follows (TODO: what is the correct type):
         1. Set |requestBody|["account_id"] to |accountId|.
         1. Set |requestBody|["client_id"] to |provider|'s {{IdentityProviderConfig/clientId}}.
         1. Set |requestBody|["nonce"] to |provider|'s {{IdentityProviderConfig/nonce}}.
     1. Let |request| be a new <a spec=fetch for=/>request</a> with the following properties:
-        1. [=request/url=] set to |tokenUrl|
+        1. [=request/url=] set to |idTokenUrl|
         1. [=request/mode=] set to "POST"
         1. [=request/body=] set to |requestBody|
         1. [=request/redirect mode=] set to "error"
         1. [=request/client=] set to null
         1. [=request/window=] set to "no-window"
         1. [=request/service-workers mode=] set to "none"
-        1. [=request/destination=] set to "identity"
+        1. [=request/destination=] set to "web-identity"
         1. [=request/origin=] set to a unique [=opaque origin=]
         1. [=request/header list=] set to a [=list=] containing a single [=header=] with
-            [=header/name=] set to "Accept" and [=header/value=] set to "JSON"
+            [=header/name=] set to "Accept" and [=header/value=] set to
+            "application/x-www-form-urlencoded"
         1. [=request/referrer=] set to [=RP=]'s URL (TODO).
         1. [=request/credentials mode=] set to "include"
     1. Let |token| be null.
     1. [=Fetch=] |request| with <a spec=fetch>processResponseConsumeBody</a> set to the following
         steps given a <a spec=fetch for=/>response</a> |response|:
-        1. If |response| is a [=network error=] or its [=response/status=] is not an [=ok status=],
-            return.
-        1. Let |mimeType| be the result of <a>extracting a MIME TYPE</a> from |response|'s
-            <a for=response>header list</a>.
-        1. If |mimeType| is failure or is not a [=JSON MIME Type=], return.
-        1. Let |json| be the result of [=parse JSON bytes to an Infra value=] passing |response|'s
-            [=response/body=].
-        1. If |json| is a parsing exception, or if |json| is not an [=ordered map=], return.
+        1. Let |json| be the result of [=extract the JSON fetch response=] from |response|.
+        1. If |json| is null, return.
         1. If |json|["token"] does not exist, or if it is not a [=string=], return.
         1. Set |token| to |json|["token"].
     1. Return |token|.
@@ -1380,7 +1397,9 @@ manipulation to fingerprint. See [[#manifest-fingerprinting]].
 <div algorithm>
 The <dfn>check the root manifest</dfn> accepts an {{IdentityProviderConfig}} |provider| and returns
 whether the manifest is included in the manifest list:
-    1. Let |configUrl| be |provider|'s {{IdentityProviderConfig/configURL}}.
+    1. Let |configUrl| be the result of running [=url parser=] with |provider|'s
+        {{IdentityProviderConfig/configURL}}.
+    1. If |configUrl| is failure, return false.
     1. Let |rootUrl| be a new [=/URL=].
     1. Set |rootUrl|'s [=url/scheme=] to |configUrl|'s [=url/scheme=].
     1. Set |rootUrl|'s [=url/host=] to |configUrl|'s [=url/host=]'s [=host/registrable domain=].
@@ -1388,11 +1407,10 @@ whether the manifest is included in the manifest list:
     1. If |rootUrl| is not a [=potentially trustworthy URL=], return false.
     1. Let |request| be a new <a spec=fetch for=/>request</a> with the following properties:
         1. [=request/url=] set to |rootUrl|
-        1. [=request/redirect mode=] set to "error"
         1. [=request/client=] set to null
         1. [=request/window=] set to "no-window"
         1. [=request/service-workers mode=] set to "none"
-        1. [=request/destination=] set to "identity"
+        1. [=request/destination=] set to "web-identity"
         1. [=request/origin=] set to a unique [=opaque origin=]
         1. [=request/header list=] set to a [=list=] containing a single [=header=] with
             [=header/name=] set to "Accept" and [=header/value=] set to "JSON"
@@ -1401,14 +1419,8 @@ whether the manifest is included in the manifest list:
     1. Let |check| be false.
     1. [=Fetch=] |request| with <a spec=fetch>processResponseConsumeBody</a> set to the following
         steps given a <a spec=fetch for=/>response</a> |response|:
-        1. If |response| is a [=network error=] or its [=response/status=] is not an [=ok status=],
-            return.
-        1. Let |mimeType| be the result of <a>extracting a MIME TYPE</a> from |response|'s
-            <a for=response>header list</a>.
-        1. If |mimeType| is failure or is not a [=JSON MIME Type=], return.
-        1. Let |json| be the result of [=parse JSON bytes to an Infra value=] passing |response|'s
-            [=response/body=].
-        1. If |json| is a parsing exception, or if |json| is not an [=ordered map=], return.
+        1. Let |json| be the result of [=extract the JSON fetch response=] from |response|.
+        1. If |json| is null, return.
         1. If |json|["provider_urls"] does not exist, or if it is not a [=list=], return.
         1. If the [=list/size=] of |json|["provider_urls"] is greater than 1, return.
 
@@ -1422,18 +1434,19 @@ whether the manifest is included in the manifest list:
 
 <div algorithm>
 The <dfn>fetch the internal manifest</dfn> algorithm accepts an {{IdentityProviderConfig}} |provider| and returns a [=Manifest=] or null if there is some failure fetching or parsing the manifest:
+    1. Let |configUrl| be the result of running [=url parser=] with |provider|'s
+        {{IdentityProviderConfig/configURL}}.
+    1. If |configUrl| is failure, return null.
     1. Run a [[!CSP]] check with a [[CSP#directive-connect-src|connect-src]]
-        directive on the URL passed as |provider|'s {{IdentityProviderConfig/configURL}}
-        and return if the check fails.
-    1. Let |url| be |provider|'s {{IdentityProviderConfig/configURL}}.
-    1. If |url| is not a [=potentially trustworthy URL=], return null.
+        directive on the URL passed as |configUrl|.
+    1. If |configUrl| is not a [=potentially trustworthy URL=], return null.
     1. Let |request| be a new <a spec=fetch for=/>request</a> with the following properties:
-        1. [=request/url=] set to |url|
+        1. [=request/url=] set to |configUrl|
         1. [=request/redirect mode=] set to "error"
         1. [=request/client=] set to null
         1. [=request/window=] set to "no-window"
         1. [=request/service-workers mode=] set to "none"
-        1. [=request/destination=] set to "identity"
+        1. [=request/destination=] set to "web-identity"
         1. [=request/origin=] set to a unique [=opaque origin=]
         1. [=request/header list=] set to a [=list=] containing a single [=header=] with
             [=header/name=] set to "Accept" and [=header/value=] set to "JSON"
@@ -1444,13 +1457,8 @@ The <dfn>fetch the internal manifest</dfn> algorithm accepts an {{IdentityProvid
     1. Let |manifest| be null.
     1. [=Fetch=] |request| with <a spec=fetch>processResponseConsumeBody</a> set to the following
         steps given a <a spec=fetch for=/>response</a> |response|:
-        1. If |response| is a [=network error=] or its [=response/status=] is not an [=ok status=],
-            return.
-        1. Let |mimeType| be the result of <a>extracting a MIME TYPE</a> from |response|'s
-            <a for=response>header list</a>.
-        1. If |mimeType| is failure or is not a [=JSON MIME Type=], return.
-        1. Let |json| be the result of [=parse JSON bytes to an Infra value=] passing |response|'s
-            [=response/body=].
+        1. Let |json| be the result of [=extract the JSON fetch response=] from |response|.
+        1. If |json| is null, return.
         1. If |json| is a parsing exception, or if |json| is not an [=ordered map=], return.
         1. If |json|["accounts_endpoint"] does not exist, or if it is not a [=string=], return.
         1. If |json|["client_metadata_endpoint"] does not exist, or if it is not a [=string=],
@@ -2059,8 +2067,9 @@ The [=user agent=] uses the following [=maybe fetch the accounts list=] in the [
 To <dfn>maybe fetch the accounts list</dfn> given a [=Manifest=] |manifest| and an {{IdentityProviderConfig}}
     |provider|:
 
-    1. Let |idpURL| be |provider|’s {{IdentityProviderConfig/configURL}}.
-    1. Let |idpOrigin| be the origin corresponding to |idpURL|.
+    1. Let |configUrl| be the result of running [=url parser=] with |provider|'s
+        {{IdentityProviderConfig/configURL}}.
+    1. Let |idpOrigin| be the origin corresponding to |configUrl|.
     1. Let |status| be the [=Sign-in Status=] of the |idpOrigin|.
     1. If |status| is {{Sign-in Status/unknown}}
         1. Let |accounts| be the result of the [=fetch the accounts list=] algorithm
@@ -2089,8 +2098,9 @@ To <dfn>maybe fetch the accounts list</dfn> given a [=Manifest=] |manifest| and 
 <div algorithm>
 To <dfn>Sign-in to the IDP</dfn> given a [=Manifest=] |manifest| and an {{IdentityProviderConfig}}
     |provider|:
-    1. Let |idpURL| be |provider|’s {{IdentityProviderConfig/configURL}}.
-    1. Let |idpOrigin| be the origin corresponding to |idpURL|.
+    1. Let |configUrl| be the result of running [=url parser=] with |provider|'s
+        {{IdentityProviderConfig/configURL}}.
+    1. Let |idpOrigin| be the origin corresponding to |configUrl|.
     1. Assert that the [=Sign-in Status=] of the |idpOrigin| is {{Sign-in Status/signed-out}}
     1. In parallel, wait until one of the following tasks returns to continue:
         1. Open a dialog that directs the user to the [=IDP=]'s {{Manifest/signin_url}}.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -605,7 +605,7 @@ which serves as a discovery device to other endpoints provided by the
 The manifest discovery endpoint is fetched:
 
 (a) **without** cookies,
-(b) **with** a special [[#Sec-FedCM-CSRF]] header,
+(b) **with** the <a http-header>Sec-Fetch-Dest</a> header set to `web-identity`,
 (c) **without** a [[RFC9110#header.referer|Referer]] header, and
 (c) **without** following [[RFC9110#header.location|HTTP redirects]].
 
@@ -616,7 +616,7 @@ For example:
 GET /config.json HTTP/1.1
 Host: idp.example
 Accept: application/json
-Sec-FedCM-CSRF: ?1
+Sec-Fetch-Dest: web-identity
 ```
 </div>
 
@@ -709,7 +709,7 @@ The accounts list endpoint provides the list of accounts the user has at the [=I
 
 The accounts list endpoint is fetched
 (a) **with** [=IDP=] cookies,
-(b) **with** a special [[#Sec-FedCM-CSRF]] header,
+(b) **with** the <a http-header>Sec-Fetch-Dest</a> header set to `web-identity`,
 (c) **without** a [[RFC9110#header.referer|Referer]] header, and
 (d) **without** following [[RFC9110#header.location|HTTP redirects]].
 
@@ -721,7 +721,7 @@ GET /accounts_list.php HTTP/1.1
 Host: idp.example
 Accept: application/json
 Cookie: 0x23223
-Sec-FedCM-CSRF: ?1
+Sec-Fetch-Dest: web-identity
 ```
 </div>
 
@@ -783,7 +783,7 @@ The client metadata endpoint provides metadata about [=RP=]s.
 
 The client medata endpoint is fetched
 (a) **without** cookies,
-(b) **with** a special [[#Sec-FedCM-CSRF]] header,
+(b) **with** the <a http-header>Sec-Fetch-Dest</a> header set to `web-identity`,
 (c) **with** a [[RFC9110#header.referer|Referer]] header indicating the [=RP=]'s origin
     (as if [[referrer-policy#referrer-policy-strict-origin|Referer-Policy: strict-origin]]
     was in use), and
@@ -799,7 +799,7 @@ GET /client_medata.php?client_id=1234 HTTP/1.1
 Host: idp.example
 Referer: https://rp.example/
 Accept: application/json
-Sec-FedCM-CSRF: ?1
+Sec-Fetch-Dest: web-identity
 ```
 </div>
 
@@ -835,7 +835,7 @@ The ID Token endpoint is fetched
 (c) **with** a [[RFC9110#header.referer|Referer]] header indicating the [=RP=]'s origin
     (as if [[referrer-policy#referrer-policy-strict-origin|Referer-Policy: strict-origin]]
     was in use),
-(d) **with** a special [[#Sec-FedCM-CSRF]] header, and
+(d) **with** the <a http-header>Sec-Fetch-Dest</a> header set to `web-identity`,
 (e) **without** following [[RFC9110#header.location|HTTP redirects]].
 
 It will also contain the following parameters in the request body `application/x-www-form-urlencoded`:
@@ -863,7 +863,7 @@ Host: idp.example
 Referer: https://rp.example/
 Content-Type: application/x-www-form-urlencoded
 Cookie: 0x23223
-Sec-FedCM-CSRF: ?1
+Sec-Fetch-Dest: web-identity
 account_id=123&client_id=client1234&nonce=Ct60bD&disclosure_text_shown=true
 ```
 </div>
@@ -901,15 +901,6 @@ For example:
 }
 ```
 </div>
-
-<!-- ============================================================ -->
-## <code><dfn data-export="">`Sec-FedCM-CSRF`</dfn></code> ## {#Sec-FedCM-CSRF}
-<!-- ============================================================ -->
-
-All FedCM HTTP requests sent by the browser must contain a header
-`Sec-FedCM-CSRF` with value `?1`. This allows servers to verify that the request
-was initiated by the browser and not untrusted JavaScript because
-it is a [=forbidden header name=].
 
 <!-- ============================================================ -->
 # The Relying Party API # {#rp-api}
@@ -1627,19 +1618,20 @@ rendering of this image is performed by the user agent, and as such this image c
 [=RP=] site nor can they be inspected by the [=RP=] in any way.
 
 <!-- ============================================================ -->
-## Sec-FedCM-CSRF Header ## {#sec-fedcm-csrf-header}
+## Sec-Fetch-Dest Header ## {#sec-fetch-dest-header}
 <!-- ============================================================ -->
 
-The FedCM API introduces several non-static endpoints on the [=IDP=], so these need to be protected
-from XSS attacks. In order to do so, the FedCM API introduces the [[#Sec-FedCM-CSRF]] header, a
-[=forbidden header name=]. The header cannot be set by random websites, so the [=IDP=] can be
-confident that the request was originated by the FedCM browser rather than sent by a websites trying
-to run an XSS attack. An [=IDP=] must to check for this header in the credentialed requests it
-receives, which ensures that the request was initiated by the user agent, based on the FedCM API. A
-malicious actor cannot spam FedCM API calls, so this is sufficient protection for the new [=IDP=]
-endpoints.
+*This section is non-normative.*
 
-Issue: There is an ongoing investigation on whether we should use this header or CORS [here](https://github.com/fedidcg/FedCM/issues/320).
+The FedCM API introduces several non-static endpoints on the [=IDP=], so these need to be protected
+from XSS attacks. In order to do so, the FedCM API introduces a new value for the
+<a http-header>Sec-Fetch-Dest</a> header, a [=forbidden header name=]. The requests initiated by the FedCM API
+have a `web-identity` value for this header. The value cannot be set by random websites, so the
+[=IDP=] can be confident that the request was originated by the FedCM browser rather than sent by a
+websites trying to run an XSS attack. An [=IDP=] must to check for this header's value in the
+credentialed requests it receives, which ensures that the request was initiated by the user agent,
+based on the FedCM API. A malicious actor cannot spam FedCM API calls, so this is sufficient
+protection for the new [=IDP=] endpoints.
 
 <!-- ============================================================ -->
 ## Browser Surface Impersonation ## {#browser-surface-impersonation}

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1174,20 +1174,9 @@ To <dfn>compute account state</dfn> given an {{IdentityProviderConfig}} |provide
 <div algorithm>
 To <dfn>fetch the accounts list</dfn> given a [=Manifest=] |manifest| and an {{IdentityProviderConfig}}
     |provider|:
-    1. Let |configUrl| be the result of running [=url parser=] with |provider|'s
-        {{IdentityProviderConfig/configURL}}.
-    1. Let |accountsUrl| be the result of running [=url parser=] given
+    1. Let |accountsUrl| be the result of [=computing the manifest URL=] given |provider| and
         |manifest|["{{Manifest/accounts_endpoint}}"].
-    1. If |accountsUrl| is failure, let |accountsUrl| be the result of running
-        [=url parser=] given |manifest|["{{Manifest/accounts_endpoint}}"] (the relative URL) and
-        |configUrl| (the base URL).
-    
-    Note: This means the we allow passing the accounts endpoint as either an absolute or relative
-        URL.
-
     1. If |accountsUrl| is failure, return an empty list.
-    1. If |accountsUrl| is not [=same origin=] with |configUrl|, return an empty list.
-    1. If |accountsUrl| is not a [=potentially trustworthy URL=], return an empty list.
     1. Let |request| be a new <a spec=fetch for=/>request</a> with the following properties:
         1. [=request/url=] set to |accountsUrl|
         1. [=request/redirect mode=] set to "error"
@@ -1197,7 +1186,7 @@ To <dfn>fetch the accounts list</dfn> given a [=Manifest=] |manifest| and an {{I
         1. [=request/destination=] set to "web-identity"
         1. [=request/origin=] set to a unique [=opaque origin=]
         1. [=request/header list=] set to a [=list=] containing a single [=header=] with
-            [=header/name=] set to "Accept" and [=header/value=] set to "JSON"
+            [=header/name=] set to `Accept` and [=header/value=] set to `application/json`
         1. [=request/referrer policy=] set to "no-referrer"
         1. [=request/credentials mode=] set to "include"
 
@@ -1227,6 +1216,22 @@ To <dfn>fetch the accounts list</dfn> given a [=Manifest=] |manifest| and an {{I
     1. Return |accountsList|.
 
         Issue: We should validate the accounts list returned here for repeated ids, as described [here](https://github.com/fedidcg/FedCM/issues/336).
+</div>
+
+<div algorithm>
+When <dfn>computing the manifest URL</dfn> given an {{IdentityProviderConfig}} |provider| and a
+[=string=] |manifestString|, perform the following steps:
+    1. Let |configUrl| be the result of running [=url parser=] with |provider|'s
+        {{IdentityProviderConfig/configURL}}.
+    1. Let |manifestUrl| be the result of running [=url parser=] given |manifestString|.
+    1. If |manifestUrl| is failure, let |manifestUrl| be the result of running [=url parser=] given
+        |manifestString| (the relative URL) and |configUrl| (the base URL).
+    
+    Note: This means the we allow passing the manifest string as either an absolute or relative URL.
+
+    1. If |manifestUrl| is failure, return failure.
+    1. If |manifestUrl| is not [=same origin=] with |configUrl|, return failure.
+    1. If |manifestUrl| is not a [=potentially trustworthy URL=], return failure.
 </div>
 
 <div algorithm>
@@ -1268,19 +1273,9 @@ To <dfn>request consent to sign-up</dfn> the user with a given [=Account JSON=] 
 <div algorithm>
 To <dfn noexport>fetch the client metadata</dfn> given a [=Manifest=] |manifest| and an
     {{IdentityProviderConfig}} |provider|, run the following steps:
-    1. Let |configUrl| be the result of running [=url parser=] with |provider|'s
-        {{IdentityProviderConfig/configURL}}.
-    1. Let |clientMetadataUrl| be the result of running [=url parser=] given
+    1. Let |clientMetadataUrl| be the result of [=computing the manifest URL=] given |provider| and
         |manifest|["{{Manifest/client_metadata_endpoint}}"].
-    1. If |clientMetadataUrl| is failure, let |clientMetadataUrl| be the result of running
-        [=url parser=] given |manifest|["{{Manifest/client_metadata_endpoint}}"] (the relative URL) and |configUrl| (the base URL).
-    
-    Note: This means the we allow passing the client metadata endpoint as either an absolute or
-        relative URL.
-
     1. If |clientMetadataUrl| is failure, return null.
-    1. If |clientMetadataUrl| is not a [=potentially trustworthy URL=], return null.
-    1. If |clientMetadataUrl| is not [=same origin=] with |configUrl|, return null.
     1. Let |request| be a new <a spec=fetch for=/>request</a> with the following properties:
         1. [=request/url=] set to |clientMetadataUrl|
         1. [=request/redirect mode=] set to "error"
@@ -1290,7 +1285,7 @@ To <dfn noexport>fetch the client metadata</dfn> given a [=Manifest=] |manifest|
         1. [=request/destination=] set to "web-identity"
         1. [=request/origin=] set to a unique [=opaque origin=]
         1. [=request/header list=] set to a [=list=] containing a single [=header=] with
-            [=header/name=] set to "Accept" and [=header/value=] set to "JSON"
+            [=header/name=] set to `Accept` and [=header/value=] set to `application/json`
         1. [=request/referrer=] set to [=RP=]'s URL (TODO).
         1. [=request/credentials mode=] set to "omit"
     1. Let |clientMetadata| be a new [=ordered map=].
@@ -1325,20 +1320,9 @@ To <dfn>create tokens</dfn> given an [=AccountState=] |accountState|, a {{USVStr
     an {{IdentityProviderConfig}} |provider|, and a [=Manifest=] |manifest|:
     1. Assert |accountState|'s {{AccountState/registration state}} is [=registered=].
     1. Assert |accountState|'s {{AccountState/allows logout}} is true.
-    1. Let |configUrl| be the result of running [=url parser=] with |provider|'s
-        {{IdentityProviderConfig/configURL}}.
-    1. Let |idTokenUrl| be the result of running [=url parser=] given
+    1. Let |idTokenUrl| be the result of [=computing the manifest URL=] given |provider| and
         |manifest|["{{Manifest/id_token_endpoint}}"].
-    1. If |idTokenUrl| is failure, let |idTokenUrl| be the result of running
-        [=url parser=] given |manifest|["{{Manifest/id_token_endpoint}}"] (the relative URL) and
-        |configUrl| (the base URL).
-    
-    Note: This means the we allow passing the id token endpoint as either an absolute or relative
-        URL.
-
     1. If |idTokenUrl| is failure, return null.
-    1. If |idTokenUrl| is not [=same origin=] with |configUrl|, return null.
-    1. If |idTokenUrl| is not a [=potentially trustworthy URL=], return null.
     1. Let |requestBody| be a [=string=] resulting in concatenating "client_id=",
         |provider|'s {{IdentityProviderConfig/clientId}}, "&nonce=",
         |provider|'s {{IdentityProviderConfig/nonce}}, "&account_id=", and |accountId|.
@@ -1353,8 +1337,8 @@ To <dfn>create tokens</dfn> given an [=AccountState=] |accountState|, a {{USVStr
         1. [=request/destination=] set to "web-identity"
         1. [=request/origin=] set to a unique [=opaque origin=]
         1. [=request/header list=] set to a [=list=] containing a single [=header=] with
-            [=header/name=] set to "Accept" and [=header/value=] set to
-            "application/x-www-form-urlencoded"
+            [=header/name=] set to `Accept` and [=header/value=] set to
+            `application/x-www-form-urlencoded`
         1. [=request/referrer=] set to [=RP=]'s URL (TODO).
         1. [=request/credentials mode=] set to "include"
     1. Let |token| be null.
@@ -1403,7 +1387,7 @@ whether the manifest is included in the manifest list:
         1. [=request/destination=] set to "web-identity"
         1. [=request/origin=] set to a unique [=opaque origin=]
         1. [=request/header list=] set to a [=list=] containing a single [=header=] with
-            [=header/name=] set to "Accept" and [=header/value=] set to "JSON"
+            [=header/name=] set to `Accept` and [=header/value=] set to `application/json`
         1. [=request/referrer policy=] set to "no-referrer"
         1. [=request/credentials mode=] set to "omit"
     1. Let |check| be false.
@@ -1439,7 +1423,7 @@ The <dfn>fetch the internal manifest</dfn> algorithm accepts an {{IdentityProvid
         1. [=request/destination=] set to "web-identity"
         1. [=request/origin=] set to a unique [=opaque origin=]
         1. [=request/header list=] set to a [=list=] containing a single [=header=] with
-            [=header/name=] set to "Accept" and [=header/value=] set to "JSON"
+            [=header/name=] set to `Accept` and [=header/value=] set to `application/json`
         1. [=request/referrer policy=] set to "no-referrer"
         1. [=request/credentials mode=] set to "omit"
     1. Let |request| be a new <a spec=fetch for=/>request</a> whose [=request/url=] is |url| and

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1098,7 +1098,8 @@ This [=internal method=] accepts three arguments:
 
         Note: Invocation of this [=internal method=] indicates that it was allowed by
         [=permissions policy=], which is evaluated at the [[!CREDENTIAL-MANAGEMENT-1]] level.
-        See [[#permissions-policy-integration]]. As such, |sameOriginWithAncestors| is unused.
+        See [[#permissions-policy-integration]]. As such,
+            <var ignore=''>sameOriginWithAncestors</var> is unused.
 
 </dl>
 
@@ -1158,7 +1159,7 @@ To <dfn>potentially create IdentityCredential</dfn>, given an {{IdentityProvider
         1. Otherwise, run the [=sign-in=] algorithm with |accountState|.
     1. If |accountState|'s {{AccountState/registration state}} is [=unregistered=] then return null.
     1. Let |token| be the result of running the [=create tokens=] algorithm with |accountState|,
-        |account|'s {{account_json/id}}, and |provider|.
+        |account|'s {{account_json/id}}, |provider|, and |manifest|.
     1. Let |credential| be a new {{IdentityCredential}}.
     1. Set |credential|'s {{IdentityCredential/token}} to |token|.
     1. Return |credential|.
@@ -1181,19 +1182,47 @@ To <dfn>compute account state</dfn> given an {{IdentityProvider}} |provider| and
 <div algorithm>
 To <dfn>fetch the accounts list</dfn> given a [=Manifest=] |manifest| and an {{IdentityProvider}}
     |provider|:
-    1. Let the |accountsEndpoint| url be the relative url
-        |manifest|["{{Manifest/accounts_endpoint}}"] of |provider|'s {{IdentityProvider/configURL}}.
-    1. Let |accountsList| be the result of fetching the |accountsEndpoint| with the
-        [=Identity Provider=]'s cookies.  This request MUST NOT follow
-        [[RFC9110#header.location|HTTP redirects]] and instead return null if there is any error.
-        See also [[#idp-api-accounts-endpoint]].
+    1. Let |accountsUrl| be the result of running [=url parser=] given
+        |manifest|[{{Manifest/accounts_endpoint}}] (the relative URL) and |provider|'s
+        {{IdentityProvider/configURL}} (the base URL).
+    1. If |accountsUrl| is failure, return an empty list.
+    1. Let |request| be a new <a spec=fetch for=/>request</a> whose [=request/url=] is
+        |accountsUrl| and [=request/redirect mode=] set to "error".
+    1. TODO: set other fields of the request, including the [[#Sec-FedCM-CSRF|Sec-FedCM-CSRF]]
+        header or equivalent, as well as using [=Identity Provider=]'s cookies.
 
         Issue: The credentialed fetch in this algorithm can lead to a timing attack that leaks the user's identities before the user consents. This is an active area of investigation that is being explored [here](https://github.com/fedidcg/FedCM/issues/230#issuecomment-1089040953).
-
+    1. Let |accountsList| be an empty list.
+    1. [=Fetch=] |request| with <a spec=fetch>processResponseConsumeBody</a> set to the following
+        steps given a <a spec=fetch for=/>response</a> |response|:
+        1. If |response| is a [=network error=] or its [=response/status=] is not an [=ok status=],
+            return.
+        1. Let |mimeType| be the result of <a>extracting a MIME TYPE</a> from |response|'s
+            <a for=response>header list</a>.
+        1. If |mimeType| is failure or is not a [=JSON MIME Type=], return.
+        1. Let |json| be the result of [=parse JSON bytes to an Infra value=] passing |response|'s
+            [=response/body=].
+        1. If |json| is a parsing exception, or if |json| is not an [=ordered map=], return.
+        1. If |json|["accounts"] does not exist, or if it is not a [=list=], return.
+        1. Let |potentialAccountsList| be an empty list.
+        1. For each |account| in |json|["accounts"]:
+            1. If |account| is not an [=ordered map=], return.
+            1. If |account|["id"] does not exist or is not a [=string=], return.
+            1. If |account|["name"] does not exist or is not a [=string=], return.
+            1. If |account|["email"] does not exist or is not a [=string=], return.
+            1. Let |acc| be a new [=Account JSON=] with {{account_json/id}} set to |account|["id"],
+                {{account_json/name}} set to |account|["name"], and {{account_json/email}} set to
+                |account|["email"].
+            1. If |account|["given_name"] exists and is a [=string=], set |acc|'s
+                {{account_json/given_name}} to |account|["given_name"].
+            1. If |account|["approved_clients"] exists and is a list where each item is a
+                [=string=], set |acc|'s {{account_json/approved_clients}} to
+                |account|["approved_clients"].
+            1. [=list/Append=] |acc| to |potentialAccountsList|.
+        1. Set |accountsList| to |potentialAccountsList|.
     1. Return |accountsList|.
 
         Issue: We should validate the accounts list returned here for repeated ids, as described [here](https://github.com/fedidcg/FedCM/issues/336).
-
 </div>
 
 <div algorithm>
@@ -1222,13 +1251,30 @@ To <dfn>request consent to sign-up</dfn> the user with a given [=Account JSON=] 
 <div algorithm>
 To <dfn noexport>fetch the client metadata</dfn> given a [=Manifest=] |manifest| and an
     {{IdentityProvider}} |provider|, run the following steps:
-    1. Let the |clientMetadataEndpoint| url be the relative url
-        |manifest|["{{Manifest/client_metadata_endpoint}}"] of |provider|'s
-        {{IdentityProvider/configURL}}.
-    1. Let the |clientMetadata| be the result of fetching the |clientMetadataEndpoint| with the
-        [[#Sec-FedCM-CSRF|Sec-FedCM-CSRF]] header but without the [=Identity Provider=]'s cookies.  This request MUST NOT follow [[RFC9110#header.location|HTTP redirects]] and instead return
-        null if there is any error. See also [[#idp-api-client-id-metadata-endpoint]].
-    1. Return |clientMetadata|.
+    1. Let |clientMetadataUrl| be the result of running [=url parser=] given
+        |manifest|["{{Manifest/client_metadata_endpoint}}"] (the relative URL) and |provider|'s
+        {{IdentityProvider/configURL}} (the base URL).
+    1. If |clientMetadataUrl| is failure, return null.
+    1. Let |request| be a new <a spec=fetch for=/>request</a> whose [=request/url=] is
+        |clientMetadataUrl| and [=request/redirect mode=] set to "error".
+    1. TODO: set other fields of the request, including the [[#Sec-FedCM-CSRF|Sec-FedCM-CSRF]]
+        header or equivalent.
+    1. Let |clientMetadata| be a new [=ordered map=].
+    1. [=Fetch=] |request| with <a spec=fetch>processResponseConsumeBody</a> set to the following
+        steps given a <a spec=fetch for=/>response</a> |response|:
+        1. If |response| is a [=network error=] or its [=response/status=] is not an [=ok status=],
+            return.
+        1. Let |mimeType| be the result of <a>extracting a MIME TYPE</a> from |response|'s
+            <a for=response>header list</a>.
+        1. If |mimeType| is failure or is not a [=JSON MIME Type=], return.
+        1. Let |json| be the result of [=parse JSON bytes to an Infra value=] passing |response|'s
+            [=response/body=].
+        1. If |json| is a parsing exception, or if |json| is not an [=ordered map=], return.
+        1. If |json|["privacy_policy_url"] exists and is a [=string=], set
+            |clientMetadata|["privacy_policy_url"] to |json|["privacy_policy_url"].
+        1. If |json|["terms_of_service_url"] exists and is a [=string=], set
+            |clientMetadata|["terms_of_service_url"] to |json|["terms_of_service_url"].
+    1. Return |clientMetadata|.    
 </div>
 
 <div algorithm>
@@ -1248,16 +1294,36 @@ To <dfn>sign-in</dfn> the user with a given an [=AccountState=] |accountState|:
 
 <div algorithm>
 To <dfn>create tokens</dfn> given an [=AccountState=] |accountState|, a {{USVString}} |accountId|,
-    and an {{IdentityProvider}} |provider|:
+    an {{IdentityProvider}} |provider|, and a [=Manifest=] |manifest|:
     1. Assert |accountState|'s {{AccountState/registration state}} is [=registered=].
     1. Assert |accountState|'s {{AccountState/allows logout}} is true.
-    1. Let |request| be a new object.
-        1. Set |request|["account_id"] to |accountId|.
-        1. Set |request|["client_id"] to |provider|'s {{IdentityProvider/clientId}}.
-        1. Set |request|["nonce"] to |provider|'s {{IdentityProvider/nonce}}.
-    1. Let |tokens| be the result of making a POST request described in
-        [[#idp-api-id-token-endpoint]].
-    1. Return |tokens|["token"].
+    1. Let |tokenUrl| be the result of running [=url parser=] given
+        |manifest|[{{Manifest/id_token_endpoint}}] (the relative URL) and |provider|'s
+        {{IdentityProvider/configURL}} (the base URL).
+    1. If |tokenUrl| is failure, return an empty list.
+    1. Let |requestBody| be a new object constructed as follows (TODO: what is the correct type):
+        1. Set |requestBody|["account_id"] to |accountId|.
+        1. Set |requestBody|["client_id"] to |provider|'s {{IdentityProvider/clientId}}.
+        1. Set |requestBody|["nonce"] to |provider|'s {{IdentityProvider/nonce}}.
+    1. Let |request| be a new <a spec=fetch for=/>request</a> whose [=request/url=] is
+        |tokenUrl|, [=request/redirect mode=] set to "error", [=request/mode=] set to `POST`, and
+        [=request/body=] set to |requestBody|.
+    1. TODO: set other fields of the request, including the [[#Sec-FedCM-CSRF|Sec-FedCM-CSRF]]
+        header or equivalent, as well as using [=Identity Provider=]'s cookies.
+    1. Let |token| be null.
+    1. [=Fetch=] |request| with <a spec=fetch>processResponseConsumeBody</a> set to the following
+        steps given a <a spec=fetch for=/>response</a> |response|:
+        1. If |response| is a [=network error=] or its [=response/status=] is not an [=ok status=],
+            return.
+        1. Let |mimeType| be the result of <a>extracting a MIME TYPE</a> from |response|'s
+            <a for=response>header list</a>.
+        1. If |mimeType| is failure or is not a [=JSON MIME Type=], return.
+        1. Let |json| be the result of [=parse JSON bytes to an Infra value=] passing |response|'s
+            [=response/body=].
+        1. If |json| is a parsing exception, or if |json| is not an [=ordered map=], return.
+        1. If |json|["token"] does not exist, or if it is not a [=string=], return.
+        1. Set |token| to |json|["token"].
+    1. Return |token|.
 </div>
 
 <div algorithm>
@@ -1280,10 +1346,10 @@ manipulation to fingerprint. See [[#manifest-fingerprinting]].
 <div algorithm>
 The <dfn>check the root manifest</dfn> accepts an {{IdentityProvider}} |provider| and returns
 whether the manifest is included in the manifest list:
-    1. Let |url| be |provider|'s {{IdentityProvider/configURL}}.
+    1. Let |configUrl| be |provider|'s {{IdentityProvider/configURL}}.
     1. Let |rootUrl| be a new [=/URL=].
-    1. Set |rootUrl|'s [=url/scheme=] to |url|'s [=url/scheme=].
-    1. Set |rootUrl|'s [=url/host=] to |url|'s [=url/host=]'s [=host/registrable domain=].
+    1. Set |rootUrl|'s [=url/scheme=] to |configUrl|'s [=url/scheme=].
+    1. Set |rootUrl|'s [=url/host=] to |configUrl|'s [=url/host=]'s [=host/registrable domain=].
     1. Set |rootUrl|'s [=url/path=] to the <a>list</a> «".well-known", "web-identity"».
     1. Let |request| be a new <a spec=fetch for=/>request</a> whose [=request/url=] is |rootUrl| and
         [=request/redirect mode=] set to "error". TODO: what other fields need to be set?
@@ -1309,18 +1375,39 @@ whether the manifest is included in the manifest list:
     1. Return |check|.
 </div>
 
-The <dfn>fetch the internal manifest</dfn> algorithm accepts an {{IdentityProvider}} |provider| and returns a [=Manifest=]:
+<div algorithm>
+The <dfn>fetch the internal manifest</dfn> algorithm accepts an {{IdentityProvider}} |provider| and returns a [=Manifest=] or null if there is some failure fetching or parsing the manifest:
     1. Run a [[!CSP]] check with a [[CSP#directive-connect-src|connect-src]]
         directive on the URL passed as |provider|'s {{IdentityProvider/configURL}}
-        and return if the check fails.
-    1. Return the result of fetching the |provider|'s {{IdentityProvider/configURL}}
-        and parsing it into a [=Manifest=]. TODO: specify how the fetching and the parsing works.
-        The fetch MUST be done with the [[#Sec-FedCM-CSRF|Sec-FedCM-CSRF]] header but without the
-        [=Identity Provider=]'s cookies. This request MUST NOT follow
-        [[RFC9110#header.location|HTTP redirects]] and instead throw an
-        error if there are any.
+        and return if the check fails. TODO: Add parameters to integrate this check into fetch.
+    1. Let |url| be |provider|'s {{IdentityProvider/configURL}}.
+    1. Let |request| be a new <a spec=fetch for=/>request</a> whose [=request/url=] is |url| and
+        [=request/redirect mode=] set to "error".
+    1. TODO: set other fields of the request, including the [[#Sec-FedCM-CSRF|Sec-FedCM-CSRF]]
+        header or equivalent.
 
         Issue: it is unclear if the [[#Sec-FedCM-CSRF|Sec-FedCM-CSRF]] header is [needed](https://github.com/fedidcg/FedCM/issues/267) on the manifest fetch.
+    1. Let |manifest| be null.
+    1. [=Fetch=] |request| with <a spec=fetch>processResponseConsumeBody</a> set to the following
+        steps given a <a spec=fetch for=/>response</a> |response|:
+        1. If |response| is a [=network error=] or its [=response/status=] is not an [=ok status=],
+            return.
+        1. Let |mimeType| be the result of <a>extracting a MIME TYPE</a> from |response|'s
+            <a for=response>header list</a>.
+        1. If |mimeType| is failure or is not a [=JSON MIME Type=], return.
+        1. Let |json| be the result of [=parse JSON bytes to an Infra value=] passing |response|'s
+            [=response/body=].
+        1. If |json| is a parsing exception, or if |json| is not an [=ordered map=], return.
+        1. If |json|["accounts_endpoint"] does not exist, or if it is not a [=string=], return.
+        1. If |json|["client_metadata_endpoint"] does not exist, or if it is not a [=string=],
+            return.
+        1. If |json|["id_token_endpoint"] does not exist, or if it is not a [=string=], return.
+        1. Set |manifest| to a new [=Manifest=] with {{Manifest/accounts_endpoint}} set to
+            |json|["accounts_endpoint"], {{Manifest/client_metadata_endpoint}} set to
+            |json|["client_metadata_endpoint"], and {{Manifest/id_token_endpoint}} set to
+            |json|["id_token_endpoint"].
+    1. Return |manifest|.
+</div>
 
 <!-- ============================================================ -->
 ### IDP Sign-out ### {#browser-api-idp-sign-out}
@@ -2007,10 +2094,6 @@ Note: write down the Acknowledgements section.
   "SAML-Glossary": {
     "href": "https://docs.oasis-open.org/security/saml/v2.0/saml-glossary-2.0-os.pdf",
     "title": "SAML glossary"
-  },
-  "Security-Origin-Confusion": {
-    "href": "https://w3c.github.io/webappsec-credential-management/#security-origin-confusion",
-    "title": "Security Origin Confusion"
   }
 }
 </pre>


### PR DESCRIPTION
Relevant issues:
* https://github.com/fedidcg/FedCM/issues/261
* https://github.com/fedidcg/FedCM/issues/320

This PR adds the fetch calls to the other FedCM fetches. It is pretty noncontroversial but is missing the majority of request parameters. A future PR will address that.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/npm1/FedCM/pull/356.html" title="Last updated on Sep 30, 2022, 7:39 PM UTC (b930834)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/fedidcg/FedCM/356/1572b7a...npm1:b930834.html" title="Last updated on Sep 30, 2022, 7:39 PM UTC (b930834)">Diff</a>