### PR TITLE
Consistently use "webidentity" as the fetch destination

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -585,7 +585,7 @@ which serves as a discovery device to other endpoints provided by the
 The manifest discovery endpoint is fetched:
 
 (a) **without** cookies,
-(b) **with** the <a http-header>Sec-Fetch-Dest</a> header set to `web-identity`,
+(b) **with** the <a http-header>Sec-Fetch-Dest</a> header set to `webidentity`,
 (c) **without** a [[RFC9110#header.referer|Referer]] header, and
 (c) **without** following [[RFC9110#header.location|HTTP redirects]].
 
@@ -596,7 +596,7 @@ For example:
 GET /config.json HTTP/1.1
 Host: idp.example
 Accept: application/json
-Sec-Fetch-Dest: web-identity
+Sec-Fetch-Dest: webidentity
 ```
 </div>
 
@@ -686,7 +686,7 @@ The accounts list endpoint provides the list of accounts the user has at the [=I
 
 The accounts list endpoint is fetched
 (a) **with** [=IDP=] cookies,
-(b) **with** the <a http-header>Sec-Fetch-Dest</a> header set to `web-identity`,
+(b) **with** the <a http-header>Sec-Fetch-Dest</a> header set to `webidentity`,
 (c) **without** a [[RFC9110#header.referer|Referer]] header, and
 (d) **without** following [[RFC9110#header.location|HTTP redirects]].
 
@@ -698,7 +698,7 @@ GET /accounts_list.php HTTP/1.1
 Host: idp.example
 Accept: application/json
 Cookie: 0x23223
-Sec-Fetch-Dest: web-identity
+Sec-Fetch-Dest: webidentity
 ```
 </div>
 
@@ -760,7 +760,7 @@ The client metadata endpoint provides metadata about [=RP=]s.
 
 The client medata endpoint is fetched
 (a) **without** cookies,
-(b) **with** the <a http-header>Sec-Fetch-Dest</a> header set to `web-identity`,
+(b) **with** the <a http-header>Sec-Fetch-Dest</a> header set to `webidentity`,
 (c) **with** a [[RFC9110#header.referer|Referer]] header indicating the [=RP=]'s origin
     (as if [[referrer-policy#referrer-policy-strict-origin|Referer-Policy: strict-origin]]
     was in use), and
@@ -776,7 +776,7 @@ GET /client_medata.php?client_id=1234 HTTP/1.1
 Host: idp.example
 Referer: https://rp.example/
 Accept: application/json
-Sec-Fetch-Dest: web-identity
+Sec-Fetch-Dest: webidentity
 ```
 </div>
 
@@ -813,7 +813,7 @@ The identity assertion endpoint is fetched
 (c) **with** a [[RFC9110#header.referer|Referer]] header indicating the [=RP=]'s origin
     (as if [[referrer-policy#referrer-policy-strict-origin|Referer-Policy: strict-origin]]
     was in use),
-(d) **with** the <a http-header>Sec-Fetch-Dest</a> header set to `web-identity`,
+(d) **with** the <a http-header>Sec-Fetch-Dest</a> header set to `webidentity`,
 (e) **without** following [[RFC9110#header.location|HTTP redirects]].
 
 It will also contain the following parameters in the request body `application/x-www-form-urlencoded`:
@@ -841,7 +841,7 @@ Host: idp.example
 Referer: https://rp.example/
 Content-Type: application/x-www-form-urlencoded
 Cookie: 0x23223
-Sec-Fetch-Dest: web-identity
+Sec-Fetch-Dest: webidentity
 account_id=123&client_id=client1234&nonce=Ct60bD&disclosure_text_shown=true
 ```
 </div>


### PR DESCRIPTION
This was incorrect in the endpoint description, but correct in the fetch algorithm calls.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cbiesinger/WebID/pull/363.html" title="Last updated on Oct 12, 2022, 12:13 PM UTC (36b5bdd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/fedidcg/FedCM/363/e842e7e...cbiesinger:36b5bdd.html" title="Last updated on Oct 12, 2022, 12:13 PM UTC (36b5bdd)">Diff</a>