### PR TITLE
Fix a few remaining mentions of id_token_endpoint

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1300,7 +1300,7 @@ To <dfn>create tokens</dfn> given an [=AccountState=] |accountState|, a {{USVStr
     1. Assert |accountState|'s {{AccountState/registration state}} is [=registered=].
     1. Assert |accountState|'s {{AccountState/allows logout}} is true.
     1. Let |idTokenUrl| be the result of [=computing the manifest URL=] given |provider| and
-        |manifest|["{{Manifest/id_token_endpoint}}"].
+        |manifest|["{{Manifest/id_assertion_endpoint}}"].
     1. If |idTokenUrl| is failure, return null.
     1. Let |requestBody| be a [=string=] resulting in concatenating "client_id=",
         |provider|'s {{IdentityProviderConfig/clientId}}, "&nonce=",
@@ -1415,11 +1415,11 @@ The <dfn>fetch the internal manifest</dfn> algorithm accepts an {{IdentityProvid
         1. If |json|["accounts_endpoint"] does not exist, or if it is not a [=string=], return.
         1. If |json|["client_metadata_endpoint"] does not exist, or if it is not a [=string=],
             return.
-        1. If |json|["id_token_endpoint"] does not exist, or if it is not a [=string=], return.
+        1. If |json|["id_assertion_endpoint"] does not exist, or if it is not a [=string=], return.
         1. Set |manifest| to a new [=Manifest=] with {{Manifest/accounts_endpoint}} set to
             |json|["accounts_endpoint"], {{Manifest/client_metadata_endpoint}} set to
-            |json|["client_metadata_endpoint"], and {{Manifest/id_token_endpoint}} set to
-            |json|["id_token_endpoint"].
+            |json|["client_metadata_endpoint"], and {{Manifest/id_assertion_endpoint}} set to
+            |json|["id_assertion_endpoint"].
     1. Return |manifest|.
 </div>
 


### PR DESCRIPTION
This has been renamed to id_assertion_endpoint in
dc52de00611969e9572b2358af9f4d01b136a177


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cbiesinger/WebID/pull/365.html" title="Last updated on Oct 14, 2022, 8:59 PM UTC (5eba8b2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/fedidcg/FedCM/365/e842e7e...cbiesinger:5eba8b2.html" title="Last updated on Oct 14, 2022, 8:59 PM UTC (5eba8b2)">Diff</a>