### PR TITLE
Allow multiple IDPs in the provider array

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1083,32 +1083,34 @@ requests.
     algorithm is invoked, the user agent MUST execute the following steps:
 
       1.  Assert: |options|["{{CredentialRequestOptions/identity}}"]["{{IdentityCredentialRequestOptions/providers}}"] [=map/exists=].
-      1.  Assert: |options|["{{CredentialRequestOptions/identity}}"]["{{IdentityCredentialRequestOptions/providers}}"] [=list/size=] is 1.
-
-           Issue: Support choosing accounts from multiple [=Identity Provider=]s, as described [here](https://github.com/fedidcg/FedCM/issues/319).
       1. Run {{setTimeout}} passing a [=task=] which throws a {{NetworkError}}, after a timeout of
           60 seconds.
 
           Note: the purpose of having a timer here is to avoid leaking the reason causing this
           method to return null. If there was no such timer, the developer could easily infer
           whether the user has an account with the [=IDP=] or not, or whether the user closed the UI without granting permission to share the [=IDP=] account information with the [=RP=].
-      1. Let |provider| be |options|["{{CredentialRequestOptions/identity}}"]["{{IdentityCredentialRequestOptions/providers}}"][0].
+      1. Let |providers| be |options|["{{CredentialRequestOptions/identity}}"]["{{IdentityCredentialRequestOptions/providers}}"].
       1. Let |credential| be the result of running the [=potentially create IdentityCredential=]
-          algorithm with |provider|.
+          algorithm with |providers|.
       1. If |credential| is null, wait for the task that throws a {{NetworkError}}, otherwise return
           |credential|.
 </div>
 
 <div algorithm>
-To <dfn>potentially create IdentityCredential</dfn>, given an {{IdentityProviderConfig}} |provider|:
-    1. Let |manifest| be the result of running the [=fetch the manifest=]
-        algorithm with |provider|.
-    1. If |manifest| is null, return null.
-    1. Let |accountsList| be the result of running the
-        [=fetch the accounts list=] algorithm with |manifest| and |provider|.
+To <dfn>potentially create IdentityCredential</dfn>, given a list of {{IdentityProviderConfig}} |providers|:
+    1. Let |accountsList| be an empty list.
+    1. For each |provider| in |providers|:
+        1. Let |manifest| be the result of running the [=fetch the manifest=]
+            algorithm with |provider|.
+        1. If |manifest| is null, return null.
+        1. Let |providerAccountsList| be the result of running the
+            [=fetch the accounts list=] algorithm with |manifest| and |provider|.
+        1. If |providerAccountsList| is non-empty, then for each entry |account|
+            in |providerAccountsList| add the pair (|account|, |provider|) to
+            |accountsList|.
     1. If |accountsList|'s size is 0, return null.
     1. If |accountsList|'s size is 1:
-        1. Let |account| be |accountsList|[0].
+        1. Let (|account|, |provider|) be |accountsList|[0].
         1. Let |accountState| be the result of running the [=compute account state=] algorithm
             given |provider| and |account|.
         1. If |accountState|'s {{AccountState/registration state}} is [=unregistered=] then run the
@@ -1117,9 +1119,10 @@ To <dfn>potentially create IdentityCredential</dfn>, given an {{IdentityProvider
         1. Otherwise, show a dialog to request user permission to sign in via |account|.
         1. If the user grants permission, run the [=sign-in=] algorithm with |accountState|.
     1. Otherwise:
-        1. Let |account| be the result of running the [=select an account=] from the
+        1. Let |entry| be the result of running the [=select an account=] from the
             |accountsList|.
-        1. If |account| is null, return null.
+        1. If |entry| is null, return null.
+        1. Let |account| be the first element of |entry| and |provider| be the second element.
         1. Let |accountState| be the result of running the [=compute account state=] algorithm
             given |provider| and |account|.
         1. If |accountState|'s {{AccountState/registration state}} is [=unregistered=] then run the
@@ -1284,8 +1287,10 @@ To <dfn>select an account</dfn> given an |accountsList|:
     1. Assert |accountsList|'s [=list/size=] is greater than 1.
     1. Display an account chooser displaying the options from |accountsList|.
     1. Let |account| be the {{account_json/id}} of the account that the user
-        manually selects from the accounts chooser, or null if no account is selected.
-    1. Return |account|
+        manually selects from the accounts chooser and |provider| be the
+        corresponding |provider| from the pair in |accountsList|, or null
+        if no account is selected.
+    1. Return (|account|, |provider|)
 </div>
 
 <div algorithm>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cbiesinger/WebID/pull/368.html" title="Last updated on Oct 19, 2022, 7:41 PM UTC (36c02ce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/fedidcg/FedCM/368/cf1e847...cbiesinger:36c02ce.html" title="Last updated on Oct 19, 2022, 7:41 PM UTC (36c02ce)">Diff</a>