### PR TITLE
Clarify how IdentityProvider is exposed

### DIFF
--- a/proposals/idp-sign-in-status-api.md
+++ b/proposals/idp-sign-in-status-api.md
@@ -56,7 +56,8 @@ was the last/only account getting signed out.
 Tentatively:
 
 ```
-partial interface IdentityProvider {
+[Exposed=Window]
+interface IdentityProvider {
   static void login();
   static void logout();
 }


### PR DESCRIPTION
This also does not need to be a partial interface.