### PR TITLE
Add Identity Provider branding name as an optional field 

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -669,6 +669,7 @@ dictionary IdentityProviderBranding {
   USVString background_color;
   USVString color;
   sequence<IdentityProviderIcon> icons;
+  USVString name;
 };
 
 dictionary IdentityProviderAPIConfig {
@@ -1076,6 +1077,8 @@ Its members have the following semantics:
     ::  [=color=] for text on [=IDP=] branded widgets.
     :   <dfn>icons</dfn>
     ::  A list of {{IdentityProviderIcon}} objects.
+    :   <dfn>name</dfn>
+    ::  A user-recognizable name for the [=IDP=].
 </dl>
 
 Note: The branding preferences are deliberately designed to be high level
@@ -1117,7 +1120,8 @@ For example:
     "icons": [{
       "url": "https://idp.example/icon.ico",
       "size": 25
-    }]
+    }],
+    "name": "IDP Example"
   }
 }
 ```


### PR DESCRIPTION
This adds one optional field to the IDP Branding information to provide a name the browser can show to represent the IDP. This shouldn't replace the IDP Site or Origin, because of security properties, but can be useful for UI elements.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bvandersloot-mozilla/FedCM/pull/432.html" title="Last updated on Feb 15, 2023, 3:51 PM UTC (b96d5bc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/fedidcg/FedCM/432/10c8d09...bvandersloot-mozilla:b96d5bc.html" title="Last updated on Feb 15, 2023, 3:51 PM UTC (b96d5bc)">Diff</a>