### PR TITLE
Adjust links to RFC9110 sections

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -984,7 +984,7 @@ The well-known file is fetched:
 (a) **without** cookies,
 (b) **with** the <a http-header>Sec-Fetch-Dest</a> header set to `webidentity`, and
 (c) **without** revealing the [=RP=] in the <a http-header>Origin</a> or
-    [[RFC9110#field.referer|Referer]] headers.
+    [[RFC9110#section-10.1.3|Referer]] headers.
 
 For example:
 
@@ -1019,8 +1019,8 @@ The config endpoint is fetched:
 (a) **without** cookies,
 (b) **with** the <a http-header>Sec-Fetch-Dest</a> header set to `webidentity`,
 (c) **without** revealing the [=RP=] in the <a http-header>Origin</a> or
-    [[RFC9110#field.referer|Referer]] headers, and
-(c) **without** following [[RFC9110#field.location|HTTP redirects]].
+    [[RFC9110#section-10.1.3|Referer]] headers, and
+(c) **without** following [[RFC9110#section-10.2.2|HTTP redirects]].
 
 For example:
 
@@ -1124,8 +1124,8 @@ The accounts list endpoint is fetched
 (a) **with** [=IDP=] cookies,
 (b) **with** the <a http-header>Sec-Fetch-Dest</a> header set to `webidentity`,
 (c) **without** revealing the [=RP=] in the <a http-header>Origin</a> or
-    [[RFC9110#field.referer|Referer]] headers, and
-(d) **without** following [[RFC9110#field.location|HTTP redirects]].
+    [[RFC9110#section-10.1.3|Referer]] headers, and
+(d) **without** following [[RFC9110#section-10.2.2|HTTP redirects]].
 
 For example:
 
@@ -1196,7 +1196,7 @@ The client medata endpoint is fetched
 (a) **without** cookies,
 (b) **with** the <a http-header>Sec-Fetch-Dest</a> header set to `webidentity`,
 (c) **with** the [=RP=]'s origin in the <a http-header>Origin</a> header, and
-(d) **without** following [[RFC9110#field.location|HTTP redirects]].
+(d) **without** following [[RFC9110#section-10.2.2|HTTP redirects]].
 
 The user agent also passes the **client_id**.
 
@@ -1246,7 +1246,7 @@ The identity assertion endpoint is fetched
 (b) **with** [=IDP=] cookies,
 (c) **with** the [=RP=]'s origin in the <a http-header>Origin</a> header, and
 (d) **with** the <a http-header>Sec-Fetch-Dest</a> header set to `webidentity`,
-(e) **without** following [[RFC9110#field.location|HTTP redirects]].
+(e) **without** following [[RFC9110#section-10.2.2|HTTP redirects]].
 
 It will also contain the following parameters in the request body `application/x-www-form-urlencoded`:
 


### PR DESCRIPTION
The cross-reference database used in Bikeshed used to contain the `httpwg.org` version of RFC9110. It now uses the `www.rfc-editor.org` version, consistent with the URL used in the References section.

This update adjusts the links to RFC9110 sections accordingly.

(Note: the cross-reference database contains the actual section IDs, e.g. `section-10.2.2`, not the section heading's IDs such as `name-location`)