### PR TITLE
Replace the 60 second timeout with a random delay

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -461,22 +461,25 @@ algorithm is invoked, the user agent MUST execute the following steps. This retu
         {{Credential/[[DiscoverFromExternalSource]](origin, options, sameOriginWithAncestors)}}
         algorithm. See <a href="https://github.com/w3c/webappsec-credential-management/issues/210">issue</a>.
 
-    1. If |credential| is failure, [=queue a global task=] on the [=DOM manipulation task source=]
-        to throw a new "{{NetworkError}}" {{DOMException}}. If |throwImmediately| is true, this
-        MUST happen after a random delay between 0 and 60 seconds.
+    1. If |credential| is a pair:
+        1. Let |throwImmediately| be the value of the second element of the pair.
+        1. [=Queue a global task=] on the [=DOM manipulation task source=]
+            to throw a new "{{NetworkError}}" {{DOMException}}. If |throwImmediately| is true, this
+            MUST happen after a random delay between 0 and 60 seconds.
+    1. Otherwise, return |credential|.
 </div>
 
 <div algorithm>
 To <dfn>create an IdentityCredential</dfn> given an {{IdentityProviderConfig}}
 |provider| and a |globalObject|, run the following steps. This returns an {{IdentityCredential}} or
-failure with an optional boolean |throwImmediately|, defaulting to false.
+a pair (failure, bool), where the bool indicates whether to skip delaying the exception throw.
     1. Assert: These steps are running [=in parallel=].
     1. Let |config| be the result of running [=fetch the config file=] with |provider| and
         |globalObject|.
-    1. If |config| is failure, return failure.
+    1. If |config| is failure, return (failure, false).
     1. Let |accountsList| be the result of [=fetch the accounts list=] with |config|, |provider|,
         and |globalObject|.
-    1. If |accountsList| is failure, return failure.
+    1. If |accountsList| is failure, return (failure, false).
     1. For each |account| in |accountsList|:
         1. If |account|["{{IdentityProviderAccount/picture}}"] is present,
             [=fetch the account picture=] with |account| and |globalObject|.
@@ -493,23 +496,21 @@ failure with an optional boolean |throwImmediately|, defaulting to false.
             with |account|, |accountState|, |config|, |provider|, and |globalObject|.
         1. Otherwise, show a dialog to request user permission to sign in via |account|, and set the
             result in |permission|.
-        1. If |permission|, [=sign-in=] with |accountState|; otherwise, return failure with
-            |throwImmediately| set to true.
+        1. If |permission|, [=sign-in=] with |accountState|; otherwise, return (failure, true).
     1. Otherwise:
         1. Let |account| be the result of running the [=select an account=] from the
             |accountsList|.
-        1. If |account| is failure, return failure with |throwImmediately| set to true.
+        1. If |account| is failure, return (failure, true).
         1. Let |accountState| be the result of running the [=compute account state=] algorithm
             given |provider| and |account|.
         1. If |accountState|'s {{AccountState/registration state}} is {{unregistered}}:
             1. Let |permission| be the result of running the [=request permission to sign-up=]
                 algorithm with |account|, |accountState|, |config|, |provider|, and |globalObject|.
-            1. If |permission|, [=sign-in=] with |accountState|; otherwise, return failure with
-                |throwImmediately| set to true.
+            1. If |permission|, [=sign-in=] with |accountState|; otherwise, return (failure, true).
         1. Otherwise, [=sign-in=] with |accountState|.
     1. Wait until the [=user agent=]'s dialog is closed.
     1. If |accountState|'s {{AccountState/registration state}} is {{unregistered}} then return
-        failure.
+        (failure, false).
     1. Let |credential| be the result of running the [=fetch an identity assertion=] algorithm with
         |accountState|, |account|'s {{IdentityProviderAccount/id}}, |provider|, |config|, and
         |globalObject|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -463,16 +463,19 @@ algorithm is invoked, the user agent MUST execute the following steps. This retu
 
     1. If |credential| is a pair:
         1. Let |throwImmediately| be the value of the second element of the pair.
+        1. If |throwImmediately| is false, the user agent SHOULD wait a random
+            amount of time between 0 and 60 seconds before the next step, unless
+            it has implemented another way to prevent exposing to the RP whether
+            the user has an account logged in to the RP.
         1. [=Queue a global task=] on the [=DOM manipulation task source=]
-            to throw a new "{{NetworkError}}" {{DOMException}}. If |throwImmediately| is true, this
-            MUST happen after a random delay between 0 and 60 seconds.
+            to throw a new "{{NetworkError}}" {{DOMException}}.
     1. Otherwise, return |credential|.
 </div>
 
 <div algorithm>
 To <dfn>create an IdentityCredential</dfn> given an {{IdentityProviderConfig}}
 |provider| and a |globalObject|, run the following steps. This returns an {{IdentityCredential}} or
-a pair (failure, bool), where the bool indicates whether to skip delaying the exception throw.
+a pair (failure, bool), where the bool indicates whether to skip delaying the exception thrown.
     1. Assert: These steps are running [=in parallel=].
     1. Let |config| be the result of running [=fetch the config file=] with |provider| and
         |globalObject|.
@@ -509,8 +512,6 @@ a pair (failure, bool), where the bool indicates whether to skip delaying the ex
             1. If |permission|, [=sign-in=] with |accountState|; otherwise, return (failure, true).
         1. Otherwise, [=sign-in=] with |accountState|.
     1. Wait until the [=user agent=]'s dialog is closed.
-    1. If |accountState|'s {{AccountState/registration state}} is {{unregistered}} then return
-        (failure, false).
     1. Let |credential| be the result of running the [=fetch an identity assertion=] algorithm with
         |accountState|, |account|'s {{IdentityProviderAccount/id}}, |provider|, |config|, and
         |globalObject|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -467,6 +467,14 @@ algorithm is invoked, the user agent MUST execute the following steps. This retu
             amount of time between 0 and 60 seconds before the next step, unless
             it has implemented another way to prevent exposing to the RP whether
             the user has an account logged in to the RP.
+
+            Note: The intention here is as follows. If we resolved the promise immediately,
+                then an RP could infer that no dialog was shown because the promise was
+                resolved quickly, after just the network delay. A shown dialog implies
+                that the user is logged in to one or more accounts of the IDP. To prevent
+                this information leakage, especially without user confirmation, we specify
+                this delay. However, UAs may have different UI approaches here and prevent
+                it in a different way.
         1. [=Queue a global task=] on the [=DOM manipulation task source=]
             to throw a new "{{NetworkError}}" {{DOMException}}.
     1. Otherwise, return |credential|.

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -464,9 +464,9 @@ algorithm is invoked, the user agent MUST execute the following steps. This retu
     1. If |credential| is a pair:
         1. Let |throwImmediately| be the value of the second element of the pair.
         1. If |throwImmediately| is false, the user agent SHOULD wait a random
-            amount of time between 0 and 60 seconds before the next step, unless
-            it has implemented another way to prevent exposing to the RP whether
-            the user has an account logged in to the RP.
+            amount of time before the next step, unless it has implemented
+            another way to prevent exposing to the RP whether the user has
+            an account logged in to the RP.
 
             Note: The intention here is as follows. If we resolved the promise immediately,
                 then an RP could infer that no dialog was shown because the promise was

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -453,15 +453,6 @@ algorithm is invoked, the user agent MUST execute the following steps. This retu
     1. Assert: |options|["{{CredentialRequestOptions/identity}}"]["{{IdentityCredentialRequestOptions/providers}}"] [=list/size=] is 1.
 
           Issue: Support choosing accounts from multiple [=IDP=]s, as described [here](https://github.com/fedidcg/FedCM/issues/319).
-    1. Run {{WindowOrWorkerGlobalScope/setTimeout()}} passing a [=task=] which throws a
-        {{NetworkError}}, after a timeout of 60 seconds.
-
-        Issue: Do not use {{WindowOrWorkerGlobalScope/setTimeout()}} directly, as that is not correct. See the relevant
-        [issue](https://github.com/fedidcg/FedCM/issues/389).
-
-        Note: the purpose of having a timer here is to avoid leaking the reason causing this
-        method to throw an error. If there was no such timer, the developer could easily infer
-        whether the user has an account with the [=IDP=] or not, or whether the user closed the UI without granting permission to share the [=IDP=] account information with the [=RP=].
     1. Let |provider| be |options|["{{CredentialRequestOptions/identity}}"]["{{IdentityCredentialRequestOptions/providers}}"][0].
     1. Let |credential| be the result of running [=create an IdentityCredential=] with |provider| and
         |globalObject|.
@@ -471,13 +462,14 @@ algorithm is invoked, the user agent MUST execute the following steps. This retu
         algorithm. See <a href="https://github.com/w3c/webappsec-credential-management/issues/210">issue</a>.
 
     1. If |credential| is failure, [=queue a global task=] on the [=DOM manipulation task source=]
-        to throw a new "{{NetworkError}}" {{DOMException}}.
+        to throw a new "{{NetworkError}}" {{DOMException}}. If |throwImmediately| is true, this
+        MUST happen after a random delay between 0 and 60 seconds.
 </div>
 
 <div algorithm>
 To <dfn>create an IdentityCredential</dfn> given an {{IdentityProviderConfig}}
 |provider| and a |globalObject|, run the following steps. This returns an {{IdentityCredential}} or
-failure.
+failure with an optional boolean |throwImmediately|, defaulting to false.
     1. Assert: These steps are running [=in parallel=].
     1. Let |config| be the result of running [=fetch the config file=] with |provider| and
         |globalObject|.
@@ -501,17 +493,19 @@ failure.
             with |account|, |accountState|, |config|, |provider|, and |globalObject|.
         1. Otherwise, show a dialog to request user permission to sign in via |account|, and set the
             result in |permission|.
-        1. If |permission|, [=sign-in=] with |accountState|.
+        1. If |permission|, [=sign-in=] with |accountState|; otherwise, return failure with
+            |throwImmediately| set to true.
     1. Otherwise:
         1. Let |account| be the result of running the [=select an account=] from the
             |accountsList|.
-        1. If |account| is failure, return failure.
+        1. If |account| is failure, return failure with |throwImmediately| set to true.
         1. Let |accountState| be the result of running the [=compute account state=] algorithm
             given |provider| and |account|.
         1. If |accountState|'s {{AccountState/registration state}} is {{unregistered}}:
             1. Let |permission| be the result of running the [=request permission to sign-up=]
                 algorithm with |account|, |accountState|, |config|, |provider|, and |globalObject|.
-            1. If |permission|, [=sign-in=] with |accountState|.
+            1. If |permission|, [=sign-in=] with |accountState|; otherwise, return failure with
+                |throwImmediately| set to true.
         1. Otherwise, [=sign-in=] with |accountState|.
     1. Wait until the [=user agent=]'s dialog is closed.
     1. If |accountState|'s {{AccountState/registration state}} is {{unregistered}} then return


### PR DESCRIPTION
This is a better user experience and also gives user agents mores
flexibility for their UI. It also makes the spec match Chrome's current
implementation.

This change does not add a delay when the user closes the dialog
explicitly. This is not necessary because the timing is effectively
random and therefore indistinguishable from other failures that do
have this delay, and it allows RPs to fall back to different types
of authentication immediately in this case.

Closes #389


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cbiesinger/WebID/pull/453.html" title="Last updated on May 9, 2023, 5:16 PM UTC (ae94804)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/fedidcg/FedCM/453/6ca279e...cbiesinger:ae94804.html" title="Last updated on May 9, 2023, 5:16 PM UTC (ae94804)">Diff</a>