### PR TITLE
Fix assertion in DiscoverFromExternalSource algorithm

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -378,7 +378,7 @@ pre-registered with (i.e. it has a `clientId`).
 
 <xmp class=idl>
 dictionary IdentityCredentialRequestOptions {
-  sequence<IdentityProviderConfig> providers;
+  required sequence<IdentityProviderConfig> providers;
 };
 </xmp>
 
@@ -448,12 +448,11 @@ When the {{IdentityCredential}}'s
 algorithm is invoked, the user agent MUST execute the following steps. This returns an
 {{IdentityCredential}} (or throws an error to the caller).
 
-    1. Assert: These steps are running [=in parallel=].
-    1. Assert: |options|["{{CredentialRequestOptions/identity}}"]["{{IdentityCredentialRequestOptions/providers}}"] [=map/exists=].
-    1. Assert: |options|["{{CredentialRequestOptions/identity}}"]["{{IdentityCredentialRequestOptions/providers}}"] [=list/size=] is 1.
+    1. If |options|["{{CredentialRequestOptions/identity}}"]["{{IdentityCredentialRequestOptions/providers}}"] [=list/size=] is not 1, throw a "{{TypeError}}" {{DOMException}}.
 
           Issue: Support choosing accounts from multiple [=IDP=]s, as described [here](https://github.com/fedidcg/FedCM/issues/319).
-    1. Run {{WindowOrWorkerGlobalScope/setTimeout()}} passing a [=task=] which throws a
+    1.  Run the following steps [=in parallel=].
+    1.  Run {{WindowOrWorkerGlobalScope/setTimeout()}} passing a [=task=] which throws a
         {{NetworkError}}, after a timeout of 60 seconds.
 
         Issue: Do not use {{WindowOrWorkerGlobalScope/setTimeout()}} directly, as that is not correct. See the relevant

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -448,10 +448,11 @@ When the {{IdentityCredential}}'s
 algorithm is invoked, the user agent MUST execute the following steps. This returns an
 {{IdentityCredential}} (or throws an error to the caller).
 
+    1. Assert: These steps are running [=in parallel=].
+    1. Assert: |options|["{{CredentialRequestOptions/identity}}"]["{{IdentityCredentialRequestOptions/providers}}"] [=map/exists=].
     1. If |options|["{{CredentialRequestOptions/identity}}"]["{{IdentityCredentialRequestOptions/providers}}"] [=list/size=] is not 1, throw a "{{TypeError}}" {{DOMException}}.
 
           Issue: Support choosing accounts from multiple [=IDP=]s, as described [here](https://github.com/fedidcg/FedCM/issues/319).
-    1.  Run the following steps [=in parallel=].
     1.  Run {{WindowOrWorkerGlobalScope/setTimeout()}} passing a [=task=] which throws a
         {{NetworkError}}, after a timeout of 60 seconds.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -453,7 +453,7 @@ algorithm is invoked, the user agent MUST execute the following steps. This retu
     1. If |options|["{{CredentialRequestOptions/identity}}"]["{{IdentityCredentialRequestOptions/providers}}"] [=list/size=] is not 1, throw a "{{TypeError}}" {{DOMException}}.
 
           Issue: Support choosing accounts from multiple [=IDP=]s, as described [here](https://github.com/fedidcg/FedCM/issues/319).
-    1.  Run {{WindowOrWorkerGlobalScope/setTimeout()}} passing a [=task=] which throws a
+    1. Run {{WindowOrWorkerGlobalScope/setTimeout()}} passing a [=task=] which throws a
         {{NetworkError}}, after a timeout of 60 seconds.
 
         Issue: Do not use {{WindowOrWorkerGlobalScope/setTimeout()}} directly, as that is not correct. See the relevant


### PR DESCRIPTION
Make `providers` required in the `identity` options dictionary so that the assert is true.
Replace the `providers` size assert with an explicit check and throw, matching chromium code.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/RByers/FedCM/pull/460.html" title="Last updated on Apr 26, 2023, 8:59 PM UTC (5345414)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/fedidcg/FedCM/460/a2437e0...RByers:5345414.html" title="Last updated on Apr 26, 2023, 8:59 PM UTC (5345414)">Diff</a>