### PR TITLE
Add disclosureTextShown to the processing logic

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1412,7 +1412,9 @@ It will also contain the following parameters in the request body `application/x
     :   <dfn>disclosure_text_shown</dfn>
     ::  Whether the user agent has explicitly shown to the user what specific information the
         [=IDP=] intends to share with the [=RP=] (e.g. "idp.example will share your name, email...
-        with rp.example"), used by the [=request permission to sign-up=] algorithm for new users.
+        with rp.example"), used by the [=request permission to sign-up=] algorithm for new users. It
+        is used as an assurance by the user agent to the [=IDP=] that it has indeed shown the terms
+        of service and privacy policy to the user in the cases where it is required to do so.
 </dl>
 
 For example:


### PR DESCRIPTION
The `disclosure_text_shown` is supposed to be part of the ID assertion fetch. It is already somewhat part of the spec but was unfortunately not properly integrated into the processing model. This PR addresses that. The `disclosure_text_shown` solves the problem that the IDP wants assurance that the user has been presented the privacy policy and terms of service to use federated login, when they are new users. Since it is now the user agent that controls the UI, it can provide that assurance to the IDP via the ID assertion request.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fedidcg/FedCM/pull/474.html" title="Last updated on Jun 8, 2023, 1:50 PM UTC (d23fac5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/fedidcg/FedCM/474/03a49d1...d23fac5.html" title="Last updated on Jun 8, 2023, 1:50 PM UTC (d23fac5)">Diff</a>