### PR TITLE
Fix bikeshed syntax errors

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -678,7 +678,7 @@ or failure.
         [pull request](https://github.com/whatwg/fetch/pull/1533) for details.
 
     1. Let |config|, |configInWellKnown| both be null.
-    1. [=Fetch request=] with |wellKnownRequest| and |globalObject|, and with <var ignore=>processResponseConsumeBody</var>
+    1. [=Fetch request=] with |wellKnownRequest| and |globalObject|, and with <var ignore>processResponseConsumeBody</var>
         set to the following steps given a <a spec=fetch for=/>response</a> |response| and |responseBody|:
         1. Let |json| be the result of [=extract the JSON fetch response=] from |response| and
             |responseBody|.
@@ -725,7 +725,7 @@ or failure.
         with [=request/mode=] set to "user-agent-no-cors". See the relevant
         [pull request](https://github.com/whatwg/fetch/pull/1533) for details.
 
-    1. [=Fetch request=] with |configRequest| and |globalObject|, and with <var ignore=>processResponseConsumeBody</var>
+    1. [=Fetch request=] with |configRequest| and |globalObject|, and with <var ignore>processResponseConsumeBody</var>
         set to the following steps given a <a spec=fetch for=/>response</a> |response| and |responseBody|:
         1. Let |json| be the result of [=extract the JSON fetch response=] from |response| and
             |responseBody|.
@@ -819,7 +819,7 @@ To <dfn>fetch the accounts list</dfn> given an {{IdentityProviderAPIConfig}} |co
         [pull request](https://github.com/whatwg/fetch/pull/1533) for details.
 
     1. Let |accountsList| be null.
-    1. [=Fetch request=] with |request| and |globalObject|, and with <var ignore=>processResponseConsumeBody</var>
+    1. [=Fetch request=] with |request| and |globalObject|, and with <var ignore>processResponseConsumeBody</var>
         set to the following steps given a <a spec=fetch for=/>response</a> |response| and |responseBody|:
         1. Let |json| be the result of [=extract the JSON fetch response=] from |response| and
             |responseBody|.
@@ -880,7 +880,7 @@ To <dfn>fetch the account picture</dfn> given an {{IdentityProviderAccount}} |ac
         with [=request/mode=] set to "user-agent-no-cors". See the relevant
         [pull request](https://github.com/whatwg/fetch/pull/1533) for details.
 
-    1. [=Fetch request=] with |pictureRequest| and |globalObject|, and with <var ignore=>processResponseConsumeBody</var>
+    1. [=Fetch request=] with |pictureRequest| and |globalObject|, and with <var ignore>processResponseConsumeBody</var>
         set to the following steps given a <var ignore=''>response</var> and a |responseBody|:
         1. If |responseBody| is null or failure, the user agent may choose an arbitrary placeholder image
             and associate it with the |account|.
@@ -942,7 +942,7 @@ To <dfn>fetch an identity assertion</dfn> given a {{USVString}}
         [pull request](https://github.com/whatwg/fetch/pull/1533) for details.
 
     1. Let |credential| be null.
-    1. [=Fetch request=] with |request| and |globalObject|, and with <var ignore=>processResponseConsumeBody</var>
+    1. [=Fetch request=] with |request| and |globalObject|, and with <var ignore>processResponseConsumeBody</var>
         set to the following steps given a <a spec=fetch for=/>response</a> |response| and |responseBody|:
         1. Let |json| be the result of [=extract the JSON fetch response=] from |response| and
             |responseBody|.
@@ -1041,7 +1041,7 @@ an {{IdentityProviderConfig}} |provider|, run the following steps. This returns 
         [pull request](https://github.com/whatwg/fetch/pull/1533) for details.
 
     1. Let |metadata| be null.
-    1. [=Fetch request=] with |request| and |globalObject|, and with <var ignore=>processResponseConsumeBody</var>
+    1. [=Fetch request=] with |request| and |globalObject|, and with <var ignore>processResponseConsumeBody</var>
         set to the following steps given a <a spec=fetch for=/>response</a> |response| and |responseBody|:
         1. Let |json| be the result of [=extract the JSON fetch response=] from |response| and
             |responseBody|.


### PR DESCRIPTION
It seems newer bikeshed versions show this error:
LINE 681:91: Missing attribute value.

Fix by using <var ignore> instead of <var ignore=>.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cbiesinger/WebID/pull/492.html" title="Last updated on Aug 11, 2023, 8:06 PM UTC (090262d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/fedidcg/FedCM/492/ba6292b...cbiesinger:090262d.html" title="Last updated on Aug 11, 2023, 8:06 PM UTC (090262d)">Diff</a>