### PR TITLE
Change confirm IDP login webdriver command to click dialog button

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2008,21 +2008,17 @@ The [=remote end steps=] are:
 1. Let |dialogButton| be the result of [=getting a property=] named
    `"dialogButton"` from |parameters|.
 
-1. If |dialogButton| is not a string that is "`ConfirmIdpLoginContinue`",
-   "`ErrorGotIt`" or "`ErrorMoreDetails`" return a [=error|WebDriver error=]
-   with [=error code=] [=invalid argument=].
+1. If |dialogButton| is not a string that is "`ConfirmIdpLoginContinue`" return
+   a [=error|WebDriver error=] with [=error code=] [=invalid argument=].
 
 1. If no FedCM dialog is currently open, or |dialogButton| is
    "`ConfirmIdpLoginContinue`" and the dialog is not a [=confirm IDP login
-   dialog=], or |dialogButton| is one of "`ErrorGotIt`" or "`ErrorMoreDetails`"
-   and the dialog is not an [=error dialog=] return a [=error|WebDriver error=]
-   with [=error code=] [=no such alert=].
+   dialog=] return a [=error|WebDriver error=] with [=error code=] [=no such
+   alert=].
 
 1. If |dialogButton| is "`ConfirmIdpLoginContinue`", act as if the user had
    clicked the "continue" button in the [=confirm IDP login dialog=] and
-   initiate the login flow. If |dialogButton| is "`ErrorGotIt`" or
-   "`ErrorMoreDetails`", act as if the user had clicked the "got it" button or
-   "more details" button respectively in the [=error dialog=].
+   initiate the login flow.
 
 1. Return [=success=] with data `null`.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2007,6 +2007,7 @@ The [=remote end steps=] are:
 
 1. Let |dialogButton| be the result of [=getting a property=] named
    `"dialogButton"` from |parameters|.
+
 1. If |dialogButton| is not a string that is "`ConfirmIdpLoginContinue`",
    "`ErrorGotIt`" or "`ErrorMoreDetails`" return a [=error|WebDriver error=]
    with [=error code=] [=invalid argument=].

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1981,9 +1981,9 @@ The [=remote end steps=] are:
 
 1. Return [=success=] with data `null`.
 
-## Confirm IDP login ## {#webdriver-confirmidplogin}
+## Click dialog button ## {#webdriver-clickdialogbutton}
 
-<figure id="table-webdriver-confirmidplogin" class="table">
+<figure id="table-webdriver-clickdialogbutton" class="table">
     <table class="data">
         <thead>
             <tr>
@@ -1994,7 +1994,7 @@ The [=remote end steps=] are:
         <tbody>
             <tr>
                 <td>POST</td>
-                <td>`/session/{session id}/fedcm/confirmidplogin`</td>
+                <td>`/session/{session id}/fedcm/clickdialogbutton`</td>
             </tr>
         </tbody>
     </table>
@@ -2002,12 +2002,26 @@ The [=remote end steps=] are:
 
 The [=remote end steps=] are:
 
-1. If no FedCM dialog is currently open, or the dialog is not a [=confirm IDP
-    login dialog=] return a [=error|WebDriver error=] with [=error code=]
-    [=no such alert=].
+1. If |parameters| is not a JSON [[ECMASCRIPT#sec-json-object|Object]], return a
+   [=error|WebDriver error=] with [=error code=] [=invalid argument=].
 
-1. Act as if the user had clicked the "continue" button in the dialog and
-    initiate the login flow.
+1. Let |dialogButton| be the result of [=getting a property=] named
+   `"dialogButton"` from |parameters|.
+1. If |dialogButton| is not a string that is "`ConfirmIdpLoginContinue`",
+   "`ErrorGotIt`" or "`ErrorMoreDetails`" return a [=error|WebDriver error=]
+   with [=error code=] [=invalid argument=].
+
+1. If no FedCM dialog is currently open, or |dialogButton| is
+   "`ConfirmIdpLoginContinue`" and the dialog is not a [=confirm IDP login
+   dialog=], or |dialogButton| is one of "`ErrorGotIt`" or "`ErrorMoreDetails`"
+   and the dialog is not an [=error dialog=] return a [=error|WebDriver error=]
+   with [=error code=] [=no such alert=].
+
+1. If |dialogButton| is "`ConfirmIdpLoginContinue`", act as if the user had
+   clicked the "continue" button in the [=confirm IDP login dialog=] and
+   initiate the login flow. If |dialogButton| is "`ErrorGotIt`" or
+   "`ErrorMoreDetails`", act as if the user had clicked the "got it" button or
+   "more details" button respectively in the [=error dialog=].
 
 1. Return [=success=] with data `null`.
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2008,12 +2008,12 @@ The [=remote end steps=] are:
 1. Let |dialogButton| be the result of [=getting a property=] named
    `"dialogButton"` from |parameters|.
 
-1. If |dialogButton| is not a string that is "`ConfirmIdpLoginContinue`" return
+1. If |dialogButton| is not a string that is "`ConfirmIdpLoginContinue`", return
    a [=error|WebDriver error=] with [=error code=] [=invalid argument=].
 
 1. If no FedCM dialog is currently open, or |dialogButton| is
    "`ConfirmIdpLoginContinue`" and the dialog is not a [=confirm IDP login
-   dialog=] return a [=error|WebDriver error=] with [=error code=] [=no such
+   dialog=], return a [=error|WebDriver error=] with [=error code=] [=no such
    alert=].
 
 1. If |dialogButton| is "`ConfirmIdpLoginContinue`", act as if the user had

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2011,14 +2011,12 @@ The [=remote end steps=] are:
 1. If |dialogButton| is not a string that is "`ConfirmIdpLoginContinue`", return
    a [=error|WebDriver error=] with [=error code=] [=invalid argument=].
 
-1. If no FedCM dialog is currently open, or |dialogButton| is
-   "`ConfirmIdpLoginContinue`" and the dialog is not a [=confirm IDP login
-   dialog=], return a [=error|WebDriver error=] with [=error code=] [=no such
-   alert=].
+1. If no FedCM dialog is currently open or the dialog is not a [=confirm IDP
+   login dialog=], return a [=error|WebDriver error=] with [=error code=] [=no
+   such alert=].
 
-1. If |dialogButton| is "`ConfirmIdpLoginContinue`", act as if the user had
-   clicked the "continue" button in the [=confirm IDP login dialog=] and
-   initiate the login flow.
+1. Act as if the user had clicked the "continue" button in the [=confirm IDP
+   login dialog=] and initiate the login flow.
 
 1. Return [=success=] with data `null`.
 


### PR DESCRIPTION
Updating the spec to repurpose confirm IDP login into click dialog button. Please take a close look, this is my first edit to the spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tttzach/FedCM/pull/510.html" title="Last updated on Nov 8, 2023, 7:32 PM UTC (73d0360)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/fedidcg/FedCM/510/c827f57...tttzach:73d0360.html" title="Last updated on Nov 8, 2023, 7:32 PM UTC (73d0360)">Diff</a>