### PR TITLE
Do not allow consider an account connected if IDP says so 

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -460,6 +460,10 @@ To <dfn>compute the connection status</dfn> given an {{IdentityProviderConfig}} 
 {{IdentityProviderAccount}} |account|, and a |globalObject|, run the following steps. This returns
 <dfn for="compute the connection status">connected</dfn> or
 <dfn for="compute the connection status">disconnected</dfn>.
+    1. If |account| [=map/contains=] {{IdentityProviderAccount/approved_clients}} and
+        |account|'s {{IdentityProviderAccount/approved_clients}} does not [=list/contain=]
+        |provider|'s {{IdentityProviderConfig/clientId}}, return
+        [=compute the connection status/disconnected=].
     1. Let |configUrl| be the result of running [=parse url=] with |provider|'s
         {{IdentityProviderConfig/configURL}} and |globalObject|.
     1. Let |idpOrigin| be the [=url/origin=] corresponding to |configUrl|.


### PR DESCRIPTION
In this PR, we fix the case where an account has been observed to be connected in the past by the user agent, but the IdP explicitly says that this account is not connected via approved_clients. This could happen if a user has revoked the federated account, and so the IdP information should be respected. In other words, if `approved_clients` is present and implies that the account is not connected, the user agent should consider it to be disconnected.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fedidcg/FedCM/pull/513.html" title="Last updated on Nov 15, 2023, 9:03 PM UTC (0fd7cc1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/fedidcg/FedCM/513/5b07ad1...0fd7cc1.html" title="Last updated on Nov 15, 2023, 9:03 PM UTC (0fd7cc1)">Diff</a>