### PR TITLE
Make typogram diagrams work in dark mode

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -74,6 +74,15 @@ dl.domintro dt code {
     padding: 8px;
     border-left: 8px solid brown;
 }
+
+/* temporary fixes to the typogram diagrams
+   to support dark mode properly */
+script + svg :is(polygon, line, rect):not(.grid) {
+  stroke: currentcolor;
+}
+script + svg :is(polygon, text) {
+  fill: currentcolor;
+}
 </style>
 
 <script src="https://fedidcg.github.io/FedCM/static/underscore-min.js"></script>


### PR DESCRIPTION
Since the typogram library explicitly uses black fill/stroke and a transparent bg, it fails badly when the spec is in dark mode. Ideally this would be fixed upstream, but for now this is a minimal fix that appears to catch everything necessary.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tabatkins/FedCM/pull/528.html" title="Last updated on Dec 18, 2023, 10:02 PM UTC (8ce0e9a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/fedidcg/FedCM/528/baf2b3d...tabatkins:8ce0e9a.html" title="Last updated on Dec 18, 2023, 10:02 PM UTC (8ce0e9a)">Diff</a>