### PR TITLE
Skip well-known check if RP and IDP are in the same site.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1030,50 +1030,50 @@ or failure.
         Note: Because domain cookies are valid across an entire site, there is no privacy
             benefit from doing the well-known check if the RP and IDP are in the same site.
     1. Otherwise:
-      1. Let |wellKnownRequest| be a new [=/request=] as follows:
+        1. Let |wellKnownRequest| be a new [=/request=] as follows:
 
-          :  [=request/URL=]
-          :: |rootUrl|
-          :  [=request/client=]
-          :: null
-          :  [=request/window=]
-          :: "no-window"
-          :  [=request/service-workers mode=]
-          :: "none"
-          :  [=request/destination=]
-          :: "webidentity"
-          :  [=request/origin=]
-          :: a unique [=opaque origin=]
-          :  [=request/header list=]
-          :: a [=list=] containing a single [=header=] with [=header/name=] set to `Accept` and
-              [=header/value=] set to `application/json`
-          :  [=request/referrer policy=]
-          :: "no-referrer"
-          :  [=request/credentials mode=]
-          :: "omit"
-          :  [=request/mode=]
-          :: "no-cors"
+            :  [=request/URL=]
+            :: |rootUrl|
+            :  [=request/client=]
+            :: null
+            :  [=request/window=]
+            :: "no-window"
+            :  [=request/service-workers mode=]
+            :: "none"
+            :  [=request/destination=]
+            :: "webidentity"
+            :  [=request/origin=]
+            :: a unique [=opaque origin=]
+            :  [=request/header list=]
+            :: a [=list=] containing a single [=header=] with [=header/name=] set to `Accept` and
+                [=header/value=] set to `application/json`
+            :  [=request/referrer policy=]
+            :: "no-referrer"
+            :  [=request/credentials mode=]
+            :: "omit"
+            :  [=request/mode=]
+            :: "no-cors"
 
-          Issue: The spec is yet to be updated so that all <a spec=fetch for=/>requests</a> are created
-          with [=request/mode=] set to "user-agent-no-cors". See the relevant
-          [pull request](https://github.com/whatwg/fetch/pull/1533) for details.
+            Issue: The spec is yet to be updated so that all <a spec=fetch for=/>requests</a> are created
+            with [=request/mode=] set to "user-agent-no-cors". See the relevant
+            [pull request](https://github.com/whatwg/fetch/pull/1533) for details.
 
-      1. [=Fetch request=] with |wellKnownRequest| and |globalObject|, and with <var ignore>processResponseConsumeBody</var>
-          set to the following steps given a <a spec=fetch for=/>response</a> |response| and |responseBody|:
-          1. Let |json| be the result of [=extract the JSON fetch response=] from |response| and
-              |responseBody|.
-          1. [=converted to an IDL value|Convert=] |json| to an {{IdentityProviderWellKnown}},
-              |discovery|.
-          1. If one of the previous two steps threw an exception, or if the
-              [=list/size=] of |discovery|["{{IdentityProviderWellKnown/provider_urls}}"] is
-              greater than 1, set |configInWellKnown| to false.
+        1. [=Fetch request=] with |wellKnownRequest| and |globalObject|, and with <var ignore>processResponseConsumeBody</var>
+            set to the following steps given a <a spec=fetch for=/>response</a> |response| and |responseBody|:
+            1. Let |json| be the result of [=extract the JSON fetch response=] from |response| and
+                |responseBody|.
+            1. [=converted to an IDL value|Convert=] |json| to an {{IdentityProviderWellKnown}},
+                |discovery|.
+            1. If one of the previous two steps threw an exception, or if the
+                [=list/size=] of |discovery|["{{IdentityProviderWellKnown/provider_urls}}"] is
+                greater than 1, set |configInWellKnown| to false.
 
-              Issue: [relax](https://github.com/fedidcg/FedCM/issues/333) the size of the
-              provider_urls array.
+                Issue: [relax](https://github.com/fedidcg/FedCM/issues/333) the size of the
+                provider_urls array.
 
-          1. Otherwise, set to |configInWellKnown| to true if
-              |discovery|["{{IdentityProviderWellKnown/provider_urls}}"][0] [=string/is=] equal to
-              |provider|'s {{IdentityProviderConfig/configURL}}, and to false otherwise.
+            1. Otherwise, set to |configInWellKnown| to true if
+                |discovery|["{{IdentityProviderWellKnown/provider_urls}}"][0] [=string/is=] equal to
+                |provider|'s {{IdentityProviderConfig/configURL}}, and to false otherwise.
 
     1. Let |configRequest| be a new <a spec=fetch for=/>request</a> as follows:
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1022,51 +1022,58 @@ or failure.
     1. Set |rootUrl|'s [=url/scheme=] to |configUrl|'s [=url/scheme=].
     1. Set |rootUrl|'s [=url/host=] to |configUrl|'s [=url/host=]'s [=host/registrable domain=].
     1. Set |rootUrl|'s [=url/path=] to the <a>list</a> «".well-known", "web-identity"».
-    1. Let |wellKnownRequest| be a new [=/request=] as follows:
-
-        :  [=request/URL=]
-        :: |rootUrl|
-        :  [=request/client=]
-        :: null
-        :  [=request/window=]
-        :: "no-window"
-        :  [=request/service-workers mode=]
-        :: "none"
-        :  [=request/destination=]
-        :: "webidentity"
-        :  [=request/origin=]
-        :: a unique [=opaque origin=]
-        :  [=request/header list=]
-        :: a [=list=] containing a single [=header=] with [=header/name=] set to `Accept` and
-            [=header/value=] set to `application/json`
-        :  [=request/referrer policy=]
-        :: "no-referrer"
-        :  [=request/credentials mode=]
-        :: "omit"
-        :  [=request/mode=]
-        :: "no-cors"
-
-        Issue: The spec is yet to be updated so that all <a spec=fetch for=/>requests</a> are created
-        with [=request/mode=] set to "user-agent-no-cors". See the relevant
-        [pull request](https://github.com/whatwg/fetch/pull/1533) for details.
-
     1. Let |config|, |configInWellKnown| both be null.
-    1. [=Fetch request=] with |wellKnownRequest| and |globalObject|, and with <var ignore>processResponseConsumeBody</var>
-        set to the following steps given a <a spec=fetch for=/>response</a> |response| and |responseBody|:
-        1. Let |json| be the result of [=extract the JSON fetch response=] from |response| and
-            |responseBody|.
-        1. [=converted to an IDL value|Convert=] |json| to an {{IdentityProviderWellKnown}},
-            |discovery|.
-        1. If one of the previous two steps threw an exception, or if the
-            [=list/size=] of |discovery|["{{IdentityProviderWellKnown/provider_urls}}"] is
-            greater than 1, set |configInWellKnown| to false.
+    1. Let |rpOrigin| be |globalObject|'s [=associated Document=]'s [=Document/origin=].
+    1. If |rootUrl|'s [=url/host=] is equal to |rpOrigin|'s [=host/registrable domain=],
+        set |configInWellKnown| to true.
 
-            Issue: [relax](https://github.com/fedidcg/FedCM/issues/333) the size of the
-            provider_urls array.
+        Note: Because domain cookies are valid across an entire site, there is no privacy
+            benefit from doing the well-known check if the RP and IDP are in the same site.
+    1. Otherwise:
+      1. Let |wellKnownRequest| be a new [=/request=] as follows:
 
-        1. Otherwise, set to |configInWellKnown| to true if
-            |discovery|["{{IdentityProviderWellKnown/provider_urls}}"][0] [=string/is=] equal to
-            |provider|'s {{IdentityProviderConfig/configURL}}, and to false otherwise.
+          :  [=request/URL=]
+          :: |rootUrl|
+          :  [=request/client=]
+          :: null
+          :  [=request/window=]
+          :: "no-window"
+          :  [=request/service-workers mode=]
+          :: "none"
+          :  [=request/destination=]
+          :: "webidentity"
+          :  [=request/origin=]
+          :: a unique [=opaque origin=]
+          :  [=request/header list=]
+          :: a [=list=] containing a single [=header=] with [=header/name=] set to `Accept` and
+              [=header/value=] set to `application/json`
+          :  [=request/referrer policy=]
+          :: "no-referrer"
+          :  [=request/credentials mode=]
+          :: "omit"
+          :  [=request/mode=]
+          :: "no-cors"
+
+          Issue: The spec is yet to be updated so that all <a spec=fetch for=/>requests</a> are created
+          with [=request/mode=] set to "user-agent-no-cors". See the relevant
+          [pull request](https://github.com/whatwg/fetch/pull/1533) for details.
+
+      1. [=Fetch request=] with |wellKnownRequest| and |globalObject|, and with <var ignore>processResponseConsumeBody</var>
+          set to the following steps given a <a spec=fetch for=/>response</a> |response| and |responseBody|:
+          1. Let |json| be the result of [=extract the JSON fetch response=] from |response| and
+              |responseBody|.
+          1. [=converted to an IDL value|Convert=] |json| to an {{IdentityProviderWellKnown}},
+              |discovery|.
+          1. If one of the previous two steps threw an exception, or if the
+              [=list/size=] of |discovery|["{{IdentityProviderWellKnown/provider_urls}}"] is
+              greater than 1, set |configInWellKnown| to false.
+
+              Issue: [relax](https://github.com/fedidcg/FedCM/issues/333) the size of the
+              provider_urls array.
+
+          1. Otherwise, set to |configInWellKnown| to true if
+              |discovery|["{{IdentityProviderWellKnown/provider_urls}}"][0] [=string/is=] equal to
+              |provider|'s {{IdentityProviderConfig/configURL}}, and to false otherwise.
 
     1. Let |configRequest| be a new <a spec=fetch for=/>request</a> as follows:
 

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1024,8 +1024,9 @@ or failure.
     1. Set |rootUrl|'s [=url/path=] to the <a>list</a> «".well-known", "web-identity"».
     1. Let |config|, |configInWellKnown| both be null.
     1. Let |rpOrigin| be |globalObject|'s [=associated Document=]'s [=Document/origin=].
-    1. If |rootUrl|'s [=url/host=] is equal to |rpOrigin|'s [=host/registrable domain=],
-        set |configInWellKnown| to true.
+    1. If |rpOrigin| is not an [=opaque origin=], and |rootUrl|'s [=url/host=] is equal
+        to |rpOrigin|'s [=host/registrable domain=], and |rootUrl|'s [=url/scheme=] is
+        equal to |rpOrigin|'s [=origin/scheme=], set |configInWellKnown| to true.
 
         Note: Because domain cookies are valid across an entire site, there is no privacy
             benefit from doing the well-known check if the RP and IDP are in the same site.


### PR DESCRIPTION
The check provides no privacy benefit (because they can share information using domain cookies) and makes it harder to test FedCM in certain staging setups.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cbiesinger/WebID/pull/535.html" title="Last updated on Jan 16, 2024, 7:01 PM UTC (e55a838)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/fedidcg/FedCM/535/828e96b...cbiesinger:e55a838.html" title="Last updated on Jan 16, 2024, 7:01 PM UTC (e55a838)">Diff</a>