### PR TITLE
Move editorship to @npm

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -6,7 +6,8 @@ Status: w3c/CG-DRAFT
 Group: fedidcg
 ED: https://fedidcg.github.io/FedCM/
 Repository: fedidcg/FedCM
-Editor: Sam Goto, Google Inc. https://google.com, goto@google.com
+Editor: Nicolás Peña Moreno, Google Inc. https://google.com, npm@chromium.org
+Former Editor: Sam Goto, Google Inc. https://google.com, goto@google.com
 
 Markup Shorthands: markdown yes, biblio yes
 Default Biblio Display: inline


### PR DESCRIPTION
As FedCM becomes more mature, this PR proposes that we start moving editorship of FedCM to @npm1 (and, ideally, a non-chrome co-editor, that we are actively looking for), to formalize an existing norm (@npm1 has been submitting more spec PR changes than myself for a considerable amount of time).

I'm still going to be around and help @npm1 through this transition, but I expect to fully transition at some point (say, by the end of the year?) out of editorship.

This PR signals that more concretely to set the expectations that @npm1 can (and should) be the primary reviewer of PRs going forward (and I can act as a secondary while @npm1 still ramps up).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fedidcg/FedCM/pull/546.html" title="Last updated on Feb 27, 2024, 4:14 PM UTC (5ff090d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/fedidcg/FedCM/546/955d4d0...5ff090d.html" title="Last updated on Feb 27, 2024, 4:14 PM UTC (5ff090d)">Diff</a>