### PR TITLE
FedCM nonce Parameter Deprecation Specification

### DIFF
--- a/explorations/nonce_deprecate.md
+++ b/explorations/nonce_deprecate.md
@@ -105,8 +105,8 @@ The browser should modify the token request generation code to extract the `nonc
 
 Relying Parties should update their code to use the new parameter location:
 
-// Before 
 ```js
+// Before
 navigator.credentials.get({
   identity: {
     providers: [{
@@ -124,8 +124,8 @@ navigator.credentials.get({
 });
 ```
 
-// After 
 ```js
+// After
 navigator.credentials.get({
   identity: {
     providers: [{
@@ -146,8 +146,8 @@ navigator.credentials.get({
 
 ### 6.1. Relying Party Implementation with New Format
 
-// Request with nonce in params object 
 ```js
+// Request with nonce in params object 
 let credential = await navigator.credentials.get({
   identity: {
     providers: [{


### PR DESCRIPTION
The Federated Credential Management (FedCM) API currently allows Identity Providers (IdPs) to specify a `nonce` parameter as a top-level field in the provider configuration object. This specification proposes deprecating this top-level parameter and moving it to the `params` object, which is the intended location for all IdP-specific parameters. This change will improve API consistency while maintaining backward compatibility during a transition period.