### PR TITLE
Explainer for IDP interception via Service Worker

### DIFF
--- a/explorations/identity_handler.md
+++ b/explorations/identity_handler.md
@@ -10,27 +10,88 @@ Suresh Potti (sureshpotti@microsoft.com)
 
 ## Summary
 
-This document describes the **FedCM Identity Handler**, a feature that allows Identity Providers (IDPs) to register a Service Worker that intercepts credentialed FedCM requests (accounts, id_assertion, disconnect). The Service Worker receives a dedicated `IdentityRequestEvent` — distinct from `FetchEvent` — providing a purpose-built, secure interception mechanism for federated identity flows.
+This document describes the **FedCM Identity Handler**, a proposed feature that would allow Identity Providers (IDPs) to register a Service Worker capable of intercepting credentialed FedCM requests (accounts, id_assertion, disconnect).
 
 ## Status
 
-This explainer documents a **proposed addition** to the FedCM specification, tracked in [PR #815](https://github.com/w3c-fedid/FedCM/pull/815). The proposal introduces a new `IdentityRequestEvent` dispatched to an IDP-controlled Service Worker for credentialed FedCM endpoints.
+This explainer documents a **proposed addition** to the FedCM specification, tracked in [PR #815](https://github.com/w3c-fedid/FedCM/pull/815). The proposal would let an IDP-controlled Service Worker intercept FedCM's credentialed fetches (accounts, id_assertion, disconnect).
+
+The underlying request was discussed in the WG on [23 September 2025](https://github.com/w3c-fedid/meetings/blob/main/2025/2025-09-23-FedCM-notes.md) and editors agreed to pursue it; the credentialed-endpoints-only scoping cleared privacy review. Spec mechanics — registration model, internal-field preservation, header allowlist, and the dispatch shape (re-using `FetchEvent` vs. a new dedicated event) — are still being worked out. See [Open Design Discussions](#open-design-discussions).
 
 ## Problem Statement
 
-Based on IDP feedback documented in [GitHub Issue #80](https://github.com/w3c-fedid/FedCM/issues/80), Identity Providers need programmable control over FedCM requests. Use cases raised include:
+The credentialed FedCM endpoints (accounts, id_assertion, disconnect) authenticate the user to the IDP using cookies. Today these requests have `service-workers mode: "none"`, so the IDP has no programmable seam between FedCM and its own network stack. The discussion on [Issue #80](https://github.com/w3c-fedid/FedCM/issues/80) surfaced four concrete problems this creates.
 
-- **Request signing (DPoP):** Add proof-of-possession assertions to prevent token theft — *"Bearer tokens have an inherent problem that they can be stolen"*
-- **Multi-domain failover:** Route requests to backup servers when primary IDP infrastructure fails
-- **Token caching during outages:** Graceful degradation when IDP servers are temporarily unavailable
-- **Geographic routing:** Direct requests to regional/sovereign identity services based on user location
-- **Legacy system integration:** Wrap non-FedCM identity services with FedCM-compatible interfaces
+### 1. Bearer-token theft on the IDP cookie
 
-Currently, FedCM requests bypass Service Workers entirely (`service-workers mode: "none"`), preventing IDPs from leveraging these programmable capabilities.
+**Challenge.** The cookies sent on the accounts and id_assertion calls are **bearer credentials** — anyone in possession of the bytes can replay them, often for the lifetime of the session (months). Token theft is a primary cause of identity-related security incidents, and modern enterprise IDPs increasingly require the cookie to be accompanied by a fresh, device-bound, proof-of-possession assertion before they will honor it. Microsoft Entra, for example, only accepts its `ESTSAUTH*` cookies if an `x-ms-RefreshTokenCredential` JWT — containing the device-wide SSO token and a server-issued nonce, signed by a TPM-backed device key — is attached to the request. Today the only way to get that header onto a FedCM-style call is via a browser extension (Chrome) or a non-standard browser API (Edge); see the [Platform Authentication explainer](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/PlatformAuthentication/explainer.md). FedCM as specified gives no place for that proof to be attached.
+
+**How SW interception helps.** If FedCM's credentialed calls were routed through an IDP-controlled Service Worker — via a `fetch` event, a dedicated identity event, or another dispatch shape still under discussion — the SW could compute its proof (DPoP, mTLS-style signature, Entra's device-key JWT, WebAuthn-derived assertion, etc.) and attach it as a request header before forwarding the request to the network. The bearer cookie alone would no longer be sufficient to replay the call — the attacker would also need the device-resident private key.
+
+> **Why not just "OAuth profile + DPoP at code redemption"?** [aaronpk's OAuth profile for FedCM](https://github.com/aaronpk/oauth-fedcm-profile) shows that DPoP-bound *RP* tokens can already be obtained without browser changes by treating the FedCM response as an authorization code and DPoP-binding the subsequent code→token exchange. That solves RP-side token binding but does **not** address the IDP-cookie bearer problem (the cookie sent on the accounts call is still a plain bearer), and the extra round trip is costly for bundle apps that talk to many IDP-issued resources (e.g., Teams). SW interception is targeted at the gap the OAuth-profile path leaves open.
+
+### 2. Hard failures during IDP outages
+
+**Challenge.** When the IDP backend is degraded — a regional incident, a partial accounts-service outage, a brief maintenance window — the FedCM call fails outright and the user sees a sign-in failure. The IDP has no opportunity to apply the resiliency patterns (regional failover, last-known-good cached account data) it routinely uses on its own surface.
+
+**How SW interception helps.** The SW is a first-class place to implement these patterns: catch the network error, retry against a backup region, or fall back to a cached account list that's recent enough to render the FedCM account chooser. The FedCM contract with the RP is unchanged; the user sees a working flow instead of a hard failure.
+
+### 3. Geographic / sovereignty-aware routing
+
+**Challenge.** Some IDPs are required (by data-residency regulations or by tenant configuration) to route a given user's authentication traffic to a specific regional service. The FedCM `config.json` declares a single set of endpoint URLs per IDP origin and is fetched without user context, so there is no point at which the IDP can pick a region based on the actual signed-in user before the accounts call goes out.
+
+**How SW interception helps.** The SW runs in the IDP origin and has access to IDP-side state (cookies, IndexedDB) that identifies the user. It can rewrite the outbound request URL to a regional endpoint at the moment the FedCM call happens, without changing the public `config.json` or requiring per-tenant config files.
+
+### 4. Bridging non-FedCM identity backends
+
+**Challenge.** An IDP with an existing identity backend whose wire format does not exactly match FedCM's accounts / id_assertion shape would otherwise have to deploy a server-side translation layer in front of every FedCM endpoint. This is operationally heavy and slows adoption — especially for IDPs experimenting with FedCM alongside an existing OIDC / SAML stack.
+
+**How SW interception helps.** The SW can act as the translation layer at the edge: receive the FedCM-shaped request, call the IDP's existing backend in its native format, and synthesize a FedCM-shaped `Response` to return via `respondWith()`. No backend rewrite is required to participate in FedCM.
 
 ## Proposed Solution
 
+### Candidate Approaches Considered
+
+Three approaches to opening the SW seam were evaluated before converging on the current direction.
+
+#### Approach A — Flip `service-workers mode` to `"all"` and let standard SW dispatch handle it
+
+The most conservative spec change: replace `service-workers mode: "none"` with `"all"` on FedCM's credentialed requests. Fetch's *HTTP fetch* algorithm would then call the Service Worker spec's [*Handle Fetch*](https://www.w3.org/TR/service-workers/#handle-fetch), which fires a `FetchEvent` at the controlling SW.
+
+**Why this cannot work as a spec-only change.** *Handle Fetch* resolves the dispatch target via the request's **client** — but FedCM sets `request's client = null` uniformly on every endpoint ([disconnect](Q:/Feature-Work/FedCM-SW/original_index.bs#L589), [well-known](Q:/Feature-Work/FedCM-SW/original_index.bs#L1187), [config](Q:/Feature-Work/FedCM-SW/original_index.bs#L1228), [accounts](Q:/Feature-Work/FedCM-SW/original_index.bs#L1353), [account picture](Q:/Feature-Work/FedCM-SW/original_index.bs#L1434), [id_assertion](Q:/Feature-Work/FedCM-SW/original_index.bs#L1503), [client_metadata](Q:/Feature-Work/FedCM-SW/original_index.bs#L1707)). With no client, the standard *Handle Fetch* algorithm has nothing to dispatch through — the request would still flow straight to the network. The `client = null` choice is structural (FedCM requests are initiated by the UA in response to the FedCM API call, not by any document-bound subresource fetch), so it cannot simply be relaxed. Additional spec machinery is required to define **how** the SW is found in the first place.
+
+#### Approach B — Browser-side dispatch layer that calls the SW directly, bypassing standard `Handle Fetch`
+
+A prototype along these lines exists at [Chromium CL 7206662](https://chromium-review.googlesource.com/c/chromium/src/+/7206662). It introduces a FedCM-specific `URLLoaderFactory` that:
+
+1. Looks up the IDP's SW registration by URL **scope** (storage-key based, not client-based).
+2. Builds a `FetchAPIRequest` from the FedCM internal request.
+3. Invokes `ServiceWorkerFetchDispatcher` directly to fire a `fetch` event at the IDP's SW.
+4. Falls back to the network factory if no SW is registered or the SW does not respond.
+
+This implements the missing dispatch primitive in the browser. However, the corresponding **spec direction** — extending Fetch / Service Worker so the *spec* can dispatch a `FetchEvent` to a SW with no controlling client — was not endorsed by reviewers on the [Chromium service-worker-discuss thread](https://groups.google.com/a/chromium.org/g/service-worker-discuss/c/t9d33x6l718):
+
+- **No initiating client** (Ben Kelly). Standard SW semantics dispatch `FetchEvent` to the SW controlling the *initiating client*. FedCM has no initiating client, and the dispatch target is the *destination* origin's SW — the same dispatch shape used by the deprecated [foreign fetch](https://github.com/whatwg/fetch/issues/506), which the SW WG removed for similar reasons.
+- **Risk to deployed SWs.** Any IDP SW with a generic `fetch` handler would suddenly receive FedCM requests it was not written to handle. The opt-in is implicit (the SW exists), not explicit.
+- **Procedural asks** (Dominic Farolino). A formal spec design section, Chrome security / privacy review, cross-vendor review, and TAG review were called out as prerequisites before reusing `FetchEvent` for this dispatch shape.
+
+CL 7206662 remains useful as a reference for the browser-side dispatch primitives, but the spec path of "reuse `FetchEvent` via *Handle Fetch*" was not pursued on the basis of the thread feedback.
+
+#### Approach C — Dedicated event, modeled on Payment Handler (current direction)
+
+The shape suggested by reviewers in the SW WG thread, and currently captured in [PR #815](https://github.com/w3c-fedid/FedCM/pull/815): introduce a purpose-built event (`IdentityRequestEvent`) that the SW must explicitly listen for. The dispatch model is borrowed directly from the [Payment Handler API](https://w3c.github.io/web-based-payment-handler/), which faces the same shape of problem (UA-initiated request, destination-origin SW, no controlling client) and resolves it the same way — Payment Handler dispatches `"paymentrequest"` (and `"canmakepayment"`) using the Service Worker spec's [*Fire Functional Event ... on registration*](https://www.w3.org/TR/service-workers/#fire-functional-event) primitive, which targets a `ServiceWorkerRegistration`'s active worker directly **without** going through *Handle Fetch* or `request's client`. That is exactly the gap that blocks Approach A, and Approach C borrows the same primitive for FedCM. (The corresponding registration surface — how the SW gets associated with a specific IDP config in the first place — is a separate question, captured in [Open Design Discussions §a](#a-service-worker-registration).)
+
+The dedicated-event design makes the unusual dispatch model **explicit at the API surface** rather than overloading `FetchEvent`. It addresses each of the Approach B concerns:
+
+- The new event has no client-resolution dependency — dispatch is anchored to whichever IDP-config-to-SW-registration binding the registration surface (see [§a](#a-service-worker-registration)) defines, and fired directly on that registration.
+- Pre-existing IDP SWs that only listen for `fetch` are not affected; only SWs that explicitly register the new event type participate.
+- Being a different event entirely sidesteps the "is this foreign fetch in disguise?" critique against reusing `FetchEvent`.
+
+This is the approach described in *How It Works* below. The detailed tradeoff comparison between Approach B and Approach C is recorded in [Open Design Discussions §d](#d-dispatch-shape--fetchevent-vs-a-dedicated-event); registration-shape options are in [§a](#a-service-worker-registration); and field-preservation mechanics are in [§b](#b-keeping-lock-down-properties-intact-when-fetch-is-called-from-the-sw).
+
 ### How It Works
+
+This section describes **Approach C** in detail.
 
 #### 1. IDP Registers a Service Worker for FedCM
 
@@ -77,25 +138,57 @@ dictionary IdentityRequestEventInit : ExtendableEventInit {
 // /idp-sw.js — IDP's Identity Handler Service Worker
 
 self.addEventListener('identityrequest', (event) => {
-  if (event.endpoint === 'accounts') {
-    // Add DPoP proof header to the accounts request
-    const augmented = new Request(event.request, {
-      headers: { ...event.request.headers, 'DPoP': generateDPoPProof() }
-    });
-    event.respondWith(fetch(augmented));
-    return;
-  }
+  switch (event.endpoint) {
+    case 'accounts':
+      // Outage resiliency: try the network, fall back to a recent cache
+      // snapshot so the FedCM account chooser still renders during a
+      // partial backend outage. (See Problem 2.)
+      event.respondWith(
+        fetch(event.request)
+          .then(response => {
+            if (response.ok) {
+              caches.open('fedcm').then(c => c.put(event.request, response.clone()));
+            }
+            return response;
+          })
+          .catch(() => caches.match(event.request))
+      );
+      break;
 
-  if (event.endpoint === 'id_assertion') {
-    // Add DPoP proof to token request
-    const augmented = new Request(event.request, {
-      headers: { ...event.request.headers, 'DPoP': generateDPoPProof() }
-    });
-    event.respondWith(fetch(augmented));
-    return;
-  }
+    case 'id_assertion':
+      // Token binding: attach a fresh DPoP proof so the IDP only honors
+      // the session cookie when accompanied by the device-resident key.
+      // (See Problem 1.)
+      event.respondWith((async () => {
+        const proof = await generateDPoPProof(event.request.url, 'POST');
+        const augmented = new Request(event.request, {
+          headers: { ...event.request.headers, 'DPoP': proof }
+        });
+        return fetch(augmented);
+      })());
+      break;
 
-  // For endpoints not handled, the browser falls back to normal network fetch
+    case 'disconnect':
+      // Bridging a non-FedCM backend: forward to the IDP's existing
+      // revocation endpoint (which doesn't return the FedCM-required
+      // shape) and synthesize a {account_id} response so the UA can
+      // remove the account from its connected accounts set.
+      event.respondWith((async () => {
+        const body = await event.request.clone().text();
+        const accountId = new URLSearchParams(body).get('account_hint');
+        const upstream = await fetch('/internal/revoke', {
+          method: 'POST',
+          body
+        });
+        if (!upstream.ok) {
+          // Surface the failure; the UA will remove all accounts for
+          // this (RP, IDP) pair, per the spec's failure handling.
+          return upstream;
+        }
+        return Response.json({ account_id: accountId });
+      })());
+      break;
+  }
 });
 ```
 
@@ -128,18 +221,6 @@ set, is still being worked out — see [Open Design Discussions §c](#c-other-ar
 ### Response Type Restriction
 
 The `Response` returned to `respondWith` must have a [response type](https://fetch.spec.whatwg.org/#concept-response-type) of `"basic"` (the response came from a same-origin fetch — i.e., from the IDP's own network endpoint) or `"default"` (the SW constructed the response directly, e.g., via `new Response(...)`, rather than fetching it). Responses of type `"cors"`, `"opaque"`, `"opaqueredirect"`, or `"error"` are rejected. This ensures the response can only originate from the IDP's own origin (or from same-origin SW code), matching the UA-direct path which uses `redirect mode: "error"` on requests whose URL targets the IDP.
-
-### Why a Dedicated Event (Not FetchEvent)?
-
-| Aspect | `FetchEvent` approach | `IdentityRequestEvent` approach |
-|--------|----------------------|-------------------------------|
-| Opt-in | Implicit (any SW intercepts) | Explicit (IDP-controlled opt-in) |
-| Scoping | SW sees ALL fetches from its origin | SW only receives identity events |
-| API surface | Generic request/response | Purpose-built: `endpoint`, `request`, `respondWith()` |
-| Augmentation policy | Open (any header) | Block-by-default allowlist |
-| Intent signaling | SW may not know it's a FedCM request | Clear `identityrequest` event type |
-
-The dedicated event approach provides clearer separation of concerns — the IDP explicitly opts in, and the SW receives a purpose-built event for identity flows.
 
 ## Benefits
 
@@ -225,6 +306,16 @@ No new information is exposed beyond what the IDP server already receives. The S
 
 User consent is still required before any tokens are issued. The SW cannot bypass the FedCM consent UI — it only augments the network layer between the browser and the IDP server.
 
+### Discussion: Privacy Attacks Considered
+
+The credentialed-endpoints-only scoping in [Selective Endpoint Policy](#selective-endpoint-policy) is the result of explicit attack analysis on Issue #80. Two attacks were considered:
+
+**Attack A — RP iframes IDP, then invokes FedCM.** The RP embeds the IDP in an iframe so the IDP's SW (or storage) sees the RP's identity, then invokes FedCM; the IDP SW correlates the RP with the user on the accounts call. **Conclusion:** this attack does not introduce new surface. Browsers already partition IndexedDB (and other SW-accessible storage) by top-frame origin, so an iframed IDP cannot stash RP context that a top-frame FedCM SW can read. To the extent IDP↔RP correlation is possible today via unpartitioned cookies or pop-ups, that correlation channel exists with or without SW interception.
+
+**Attack B — uncredentialed endpoint logs the RP, credentialed endpoint reads it.** If SW interception were enabled on uncredentialed endpoints (e.g., `client_metadata`), the IDP SW could record the RP identity from that call (which legitimately includes the RP's `client_id`) and read it back during the subsequent accounts call — combining user identity (via cookies on the accounts call) and RP identity in the same SW context. **Conclusion:** real attack. Resolved by restricting SW interception to credentialed endpoints only (accounts, id_assertion, disconnect) and continuing to fetch configuration / metadata / well-known endpoints UA-direct with the existing privacy properties.
+
+The privacy reviewer for the WG cleared the credentialed-only proposal on this basis.
+
 ## Security Considerations
 
 ### Origin Isolation
@@ -241,9 +332,21 @@ Cross-origin Service Worker interception is architecturally impossible.
 
 ### Sec-Fetch-Dest: webidentity
 
-FedCM requests include `Sec-Fetch-Dest: webidentity`, a forbidden header that cannot be set by JavaScript. The `Request` object exposed to the SW has `destination: "webidentity"`, which the SW can **read** but cannot **set**. IDPs can validate this header server-side to confirm requests genuinely originate from the FedCM API.
+On the UA-direct path, the browser stamps `Sec-Fetch-Dest: webidentity` — a forbidden header JavaScript cannot set — so the IDP can confirm the request came from the FedCM API, not from page-initiated script. The SW path must preserve the same guarantee: `event.request.destination` is `"webidentity"` (read-only to the SW), and the header must reach the IDP unchanged when the SW forwards the request. Otherwise the SW path silently weakens a marker the UA-direct path provides.
 
-> The UA sets a number of internal fields on the FedCM request (`client`, `origin`, `destination`, `redirect mode`, `credentials mode`, `referrer policy`, `mode`, etc.) that together determine the on-the-wire shape — including `Sec-Fetch-Dest: webidentity`, the cookie scope (`SameSite=None`-only), and the value of the `Origin:` header. These fields are expected to remain intact end-to-end. However, when the SW forwards the request via `fetch(event.request)`, some of these fields may get reset as the request passes through the public `Request` constructor / Fetch algorithm, which can change the on-the-wire behavior. How the spec preserves these fields across SW forwarding is an open design question — see [Open Design Discussions §b](#b-keeping-lock-down-properties-intact-when-fetch-is-called-from-the-sw).
+> **Why preserve `Sec-Fetch-Dest: webidentity` if the SW is already attaching a PoP proof?**
+>
+> A reasonable question — if the SW attaches a DPoP / Entra-JWT / mTLS-style proof, does the UA-stamped `Sec-Fetch-Dest: webidentity` marker still matter? Three reasons it does:
+>
+> 1. **Not every IDP attaches PoP.** SW interception is opt-in, and even an IDP that ships a SW may not attach a proof to every request. The spec must work for IDPs that rely only on cookies. `Sec-Fetch-Dest: webidentity` is the universal CSRF marker that lets *any* IDP server tell a real FedCM call apart from a page-initiated XHR — independent of whether a PoP scheme is in play.
+>
+> 2. **PoP and `Sec-Fetch-Dest` answer different questions.** PoP says "this request came from a holder of this device's private key." `Sec-Fetch-Dest: webidentity` says "this request came through the FedCM API surface, with the UA's mediation and consent UI." An IDP may legitimately want both: a credential is only honored if it is *both* device-bound *and* arriving on the FedCM path — so the server can be sure the matching consent flow ran. PoP alone does not vouch for the path the request took.
+>
+> 3. **The cookie-scope invariant is unrelated to PoP.** The UA-stamped opaque `origin` is what causes the cookie layer to send only `SameSite=None` cookies. If the SW path resets `origin` to `https://idp.example`, *all* same-site cookies (`Lax`, `Strict`) are sent on the wire — a data exposure that PoP does not undo. Preserving the lock-down protects this property regardless of whether the IDP attaches a proof.
+>
+> Put differently: PoP is an *IDP-defined* assertion about the client. The lock-down (`Sec-Fetch-Dest`, opaque origin, `redirect mode: "error"`, `referrer policy: "no-referrer"`) is a *UA-vouched* set of properties about how the request was made. They are layered defenses, not substitutes.
+
+When the SW forwards the request via `fetch(event.request)`, that preservation is at risk — passing through the public `Request` constructor / Fetch algorithm can reset some of the UA-set internal fields. How the spec preserves these fields end-to-end across SW forwarding is an open design question — see [Open Design Discussions §b](#b-keeping-lock-down-properties-intact-when-fetch-is-called-from-the-sw).
 
 ### Redirect Prevention
 
@@ -287,7 +390,7 @@ Options under consideration include:
 - **Opt-in flag on the existing registration.** The IDP registers its SW with the standard `navigator.serviceWorker.register(...)` API and passes a new option (e.g., `acceptsFedCM: true`) on `RegistrationOptions`. SWs without the flag are invisible to FedCM dispatch. Lowest spec and IDP cost; the SW lifecycle remains owned by the IDP page.
 - **Dedicated FedCM-only registration.** A separate `registerForFedCM(...)` API stores the FedCM SW in a parallel registry that is invisible to `getRegistration()` / `getRegistrations()`. Strongest registry-level isolation but a much larger spec surface (new IDL, new lifecycle algorithms, cross-cutting interactions with `Clients`, `BroadcastChannel`, push, etc.), and IDPs run two SWs with shared-state coordination.
 - **Separate FedCM storage partition.** Adds a separate storage partition on top of the dedicated registration. Maximal isolation, but IDPs cannot share keys / caches / preferences across the two SWs without runtime `postMessage` choreography.
-- **Dedicated manager extending `ServiceWorkerRegistration` (e.g., `registration.identity`).** Follow the architectural pattern used by features like the Periodic Background Sync API and the Notification API: extend `ServiceWorkerRegistration` with a dedicated interface — for example, `registration.identity` (an `IdentityProviderManager`). To enable FedCM interception, the IDP would call `registration.identity.register(configURL)` explicitly. This creates a one-to-one mapping between the IDP config URL and the SW registration, so functional events are only dispatched to workers that have intentionally opted in for that specific provider. (`configURL` is used here because it is the unique identifier for an `IdentityProviderConfig`.) This addresses the semantic mismatch of using the implicit `Match Service Worker Registration` algorithm for internal UA requests that lack a controlled client. It also provides a clear lifecycle: unlinking via `registration.identity.unregister(configURL)`, or implicitly through removal of the parent registration.
+- **Dedicated manager extending `ServiceWorkerRegistration` (e.g., `registration.identity`).** Follow the architectural pattern used by the [Payment Handler API](https://w3c.github.io/web-based-payment-handler/) — and similar features like Periodic Background Sync and Notifications — by extending `ServiceWorkerRegistration` with a dedicated interface. Payment Handler does this with `registration.paymentManager`, on which the page calls `paymentManager.instruments.set(instrumentKey, ...)` to declare what the handler can serve. FedCM would do the same with `registration.identity` (an `IdentityProviderManager`) and `registration.identity.register(configURL)`. This creates a one-to-one mapping between the IDP config URL and the SW registration, so functional events are only dispatched to workers that have intentionally opted in for that specific provider. (`configURL` is used here because it is the unique identifier for an `IdentityProviderConfig`.) This addresses the semantic mismatch of using the implicit `Match Service Worker Registration` algorithm for internal UA requests that lack a controlled client. It also provides a clear lifecycle: unlinking via `registration.identity.unregister(configURL)`, or implicitly through removal of the parent registration. **Of the options listed here, this is the closest precedent to Payment Handler's shape and the most direct fit for the dispatch primitive Approach C relies on.**
 
 Reviewer concerns this section needs to resolve:
 
@@ -337,12 +440,33 @@ Approaches under consideration:
 
 Whichever approach is chosen, the spec requires the same end-state: the request that hits the wire after SW forwarding is byte-for-byte equivalent to the UA-direct request (optionally with allowlisted augmenting headers added).
 
+### d) Dispatch Shape — `FetchEvent` vs. a Dedicated Event
+
+How should the FedCM credentialed call surface inside the SW? The two shapes under consideration are:
+
+- **Reuse `FetchEvent`.** The browser routes the FedCM internal request through the standard SW dispatch path; the IDP's existing `fetch` handler sees the request (distinguished by `Sec-Fetch-Dest: webidentity` and `request.destination === "webidentity"`) and decides whether to handle it.
+- **Introduce a dedicated event** (e.g., `IdentityRequestEvent`). The browser dispatches a purpose-built event the SW must explicitly listen for; SWs that only have a `fetch` handler are not invoked.
+
+The tradeoffs were discussed on the [Chromium service-worker-discuss thread](https://groups.google.com/a/chromium.org/g/service-worker-discuss/c/t9d33x6l718). At a high level:
+
+| Aspect | `FetchEvent` reuse | Dedicated event |
+|---|---|---|
+| Spec surface | Smallest — a flag flip on `service-workers mode` plus the augmenting-header rules | Larger — new IDL, new dispatch algorithm |
+| Opt-in model | Implicit — any SW with a `fetch` handler that happens to match the URL would intercept | Explicit — only SWs that register the new event type participate |
+| Risk to deployed SWs | Pre-existing IDP SWs deployed for caching / push / offline would suddenly receive FedCM requests they were not written to handle | None — the new event is invisible to existing handlers |
+| Alignment with SW architecture | Concerns raised on the thread that FedCM's request — which has no controlled client and is dispatched to the *destination* origin's SW rather than an *initiating* origin's SW — does not fit standard subresource-fetch semantics, and resembles the deprecated [foreign fetch](https://github.com/whatwg/fetch/issues/506) | A dedicated event makes the unusual dispatch model explicit at the API level rather than overloading `FetchEvent` |
+| Reviewer asks | The thread (D. Farolino, B. Kelly) called for a formal spec design doc, Chrome security/privacy review, other-vendor review, and TAG review before reusing `FetchEvent` for this | Largely sidesteps the "is this foreign fetch in disguise?" critique by being a different event entirely |
+
+**Status.** No final decision. The dedicated-event direction is currently captured in [PR #815](https://github.com/w3c-fedid/FedCM/pull/815) and is the shape used in this explainer's examples, but the choice is not settled.
+
 ## References
 
 - [FedCM Specification](https://fedidcg.github.io/FedCM/)
 - [FedCM Identity Handler section](https://fedidcg.github.io/FedCM/#identity-handler)
 - [Spec PR #815 — Enabling IDP Interception in FedCM Request](https://github.com/w3c-fedid/FedCM/pull/815)
 - [GitHub Issue #80 — SW interception for FedCM](https://github.com/w3c-fedid/FedCM/issues/80)
+- [WG meeting notes (23 Sept 2025) — agreement to pursue SW interception](https://github.com/w3c-fedid/meetings/blob/main/2025/2025-09-23-FedCM-notes.md)
+- [Chromium service-worker-discuss thread — FedCM SW interception](https://groups.google.com/a/chromium.org/g/service-worker-discuss/c/t9d33x6l718)
 - [Service Worker Specification](https://w3c.github.io/ServiceWorker/)
 - [Fetch Specification](https://fetch.spec.whatwg.org/)
 - [DPoP (RFC 9449)](https://www.rfc-editor.org/rfc/rfc9449)

--- a/explorations/identity_handler.md
+++ b/explorations/identity_handler.md
@@ -6,181 +6,414 @@ Suresh Potti (sureshpotti@microsoft.com)
 ## Participate
 
 - https://github.com/w3c-fedid/FedCM/issues/80
+- https://github.com/w3c-fedid/FedCM/pull/815 (spec PR)
 - https://fedidcg.github.io/FedCM/#identity-handler
 
 ## Summary
 
-This document describes the **FedCM Identity Handler**, a feature that allows Identity Providers (IDPs) to declare a Service Worker in their FedCM `config.json` that intercepts credentialed FedCM requests (accounts, id_assertion, disconnect). The Service Worker receives a dedicated `IdentityRequestEvent` — distinct from `FetchEvent` — providing a purpose-built, secure interception mechanism for federated identity flows.
+This document describes the **FedCM Identity Handler**, a feature that allows Identity Providers
+(IDPs) to opt their existing Service Worker into intercepting credentialed FedCM requests
+(`accounts`, `id_assertion`, `disconnect`). When opted in, the Service Worker receives a dedicated
+`IdentityRequestEvent` — distinct from `FetchEvent` — and can forward the request to the network
+using a purpose-built `fetchAugmented()` method that preserves the UA's privileged request
+properties while allowing a small, vetted set of augmenting headers (e.g., `DPoP`).
 
 ## Status
 
-This explainer documents a **proposed addition** to the FedCM specification. The proposal introduces a new `identity_handler` field in the IDP config and a corresponding `IdentityRequestEvent` dispatched to the IDP's Service Worker.
+This explainer documents a **proposed addition** to the FedCM specification, tracked in
+[PR #815](https://github.com/w3c-fedid/FedCM/pull/815). The proposal introduces:
 
-**Key difference from generic SW interception:** Rather than changing `service-workers mode` from `"none"` to `"all"` on FedCM requests (which would use the standard `FetchEvent` pathway), this proposal introduces a dedicated event type that the browser dispatches only when an IDP explicitly opts in via their config. This provides clearer intent signaling, tighter scoping, and a purpose-built API surface.
+1. An **opt-in flag** (`acceptsFedCM: true`) on the existing `ServiceWorkerContainer.register()`
+   call, so that only Service Workers that explicitly opt in are reachable by FedCM dispatch.
+2. A dedicated `IdentityRequestEvent` dispatched to the opted-in SW.
+3. A purpose-built `IdentityRequestEvent.fetchAugmented(init)` method that forwards the UA's
+   privileged internal request to the network while letting the SW append a small allowlist of
+   augmenting headers.
+
+> **Note — substantial discussion in PR #815.** Earlier drafts of this explainer described a
+> *config-based* registration model in which the IDP declared a Service Worker via an
+> `identity_handler` field in `config.json` and the browser managed registration / unregistration
+> lifecycle. Based on reviewer feedback on PR #815, that approach has been replaced by the
+> opt-in flag described in this document. The flag-based model keeps the SW lifecycle in the
+> hands of the IDP (via the standard Service Worker registration APIs) while still preventing
+> pre-existing SWs from accidentally intercepting FedCM events. See the section
+> *[SW Registration Model](#sw-registration-model)* for the full rationale and
+> *[Alternatives Considered](#alternatives-considered)* for the design space.
+
+**Key difference from generic SW interception:** Rather than changing the FedCM internal request's
+`service-workers mode` from `"none"` to `"all"` (which would route through the standard
+`FetchEvent` pathway and *lose* the UA-set privileged properties when the SW called
+`fetch(event.request)`), this proposal introduces a dedicated event type plus a dedicated
+forwarding method (`fetchAugmented`) that the browser dispatches only when the IDP's SW has
+explicitly opted in. This provides clearer intent signaling, tighter scoping, a purpose-built API
+surface, and — crucially — byte-for-byte preservation of the UA-direct request shape on the wire.
 
 ## Problem Statement
 
-Based on IDP feedback documented in [GitHub Issue #80](https://github.com/w3c-fedid/FedCM/issues/80), Identity Providers need programmable control over FedCM requests. Use cases raised include:
+Based on IDP feedback documented in [GitHub Issue #80](https://github.com/w3c-fedid/FedCM/issues/80),
+Identity Providers need programmable control over FedCM requests. Use cases raised include:
 
-- **Request signing (DPoP):** Add proof-of-possession assertions to prevent token theft — *"Bearer tokens have an inherent problem that they can be stolen"*
-- **Multi-domain failover:** Route requests to backup servers when primary IDP infrastructure fails
-- **Token caching during outages:** Graceful degradation when IDP servers are temporarily unavailable
-- **Geographic routing:** Direct requests to regional/sovereign identity services based on user location
-- **Legacy system integration:** Wrap non-FedCM identity services with FedCM-compatible interfaces
+- **Request signing (DPoP):** Add proof-of-possession assertions to prevent token theft — *"Bearer
+  tokens have an inherent problem that they can be stolen."*
+- **Multi-domain failover:** Route requests to backup servers when primary IDP infrastructure fails.
+- **Token caching during outages:** Graceful degradation when IDP servers are temporarily
+  unavailable.
+- **Geographic routing:** Direct requests to regional / sovereign identity services based on user
+  location.
+- **Legacy system integration:** Wrap non-FedCM identity services with FedCM-compatible interfaces.
 
-Currently, FedCM requests bypass Service Workers entirely (`service-workers mode: "none"`), preventing IDPs from leveraging these programmable capabilities.
+Currently, FedCM internal requests have `service-workers mode: "none"`, so SW interception is
+impossible — IDPs cannot leverage these programmable capabilities.
 
 ## Proposed Solution
 
-### How It Works
+### 1. IDP Opts Its Service Worker Into FedCM
 
-#### 1. IDP Declares a Service Worker in Config
+The IDP registers its Service Worker using the standard
+[`ServiceWorkerContainer.register()`](https://w3c.github.io/ServiceWorker/#dom-serviceworkercontainer-register)
+API and passes a new `acceptsFedCM` option:
 
-The IDP adds an `identity_handler` field to their FedCM `config.json`:
-
-```json
-{
-  "accounts_endpoint": "/accounts",
-  "id_assertion_endpoint": "/token",
-  "disconnect_endpoint": "/disconnect",
-  "login_url": "/login",
-  "identity_handler": {
-    "service_worker": "/idp-sw.js"
-  }
-}
+```js
+navigator.serviceWorker.register('/sw.js', {
+  scope: '/',
+  acceptsFedCM: true   // ← opts this SW into FedCM dispatch
+});
 ```
 
-When the browser fetches this config, it registers the declared Service Worker at the IDP origin. If the IDP later removes `identity_handler` from their config, the browser automatically unregisters the SW (fire-and-forget cleanup).
+**Spec change in summary:**
 
-#### 2. Browser Dispatches `IdentityRequestEvent` to the SW
+- A new boolean `acceptsFedCM` field on `RegistrationOptions` (defaults to `false`).
+- A new step in the `dispatch identity handler` algorithm: after `Match Service Worker
+  Registration`, if the registration's `acceptsFedCM` is `false`, return null (no SW interception).
 
-When the browser needs to fetch an IDP endpoint (accounts, token, disconnect), it first dispatches an `IdentityRequestEvent` to the registered SW:
+A Service Worker without `acceptsFedCM: true` is **invisible** to FedCM dispatch — even if it
+adds an `identityrequest` event listener, the UA will never dispatch to it. This preserves the
+existing behavior of every SW deployed today.
+
+> **Note — substantial discussion in PR #815: registration isolation.** Reviewer feedback raised
+> the concern that pre-existing SWs (e.g., deployed for caching, push, offline) should not
+> accidentally be invoked for FedCM, and that FedCM-purposed SWs should not be misused by other
+> platform features that look up the same registration. The opt-in flag addresses both concerns
+> at minimal spec and IDP cost. Stronger forms of isolation (separate FedCM-only registration
+> registry, or even a separate storage partition) were considered and are documented under
+> [Alternatives Considered](#alternatives-considered).
+
+### SW Registration Model
+
+The Identity Handler SW is registered the same way any SW is registered: from a page on the IDP
+origin, via `navigator.serviceWorker.register(...)`. The only addition is the `acceptsFedCM`
+option.
+
+This is a deliberate change from earlier drafts, which proposed that the browser register the SW
+automatically based on an `identity_handler` field in `config.json`. The browser-managed model
+was rejected because:
+
+1. **Lifecycle ownership is unclear.** The standard SW lifecycle (install / activate / update /
+   unregister) is owned by the page that registered the SW. A browser-injected registration with
+   no owning page creates novel lifecycle questions (when is it updated? what triggers
+   `updatefound`? how does it interact with `Clear-Site-Data`?).
+2. **Scope semantics differ.** SW scope is usually derived from the registering script's URL.
+   A config-driven registration has no obvious natural scope.
+3. **Developer expectations diverge.** SWs registered outside of `navigator.serviceWorker` do not
+   appear in `getRegistrations()` and are not visible in DevTools' Service Workers panel without
+   special handling. The flag-based model "just works" with existing tooling.
+
+> **Note — substantial discussion in PR #815: unregistration.** Reviewers asked how the SW gets
+> unregistered when the IDP no longer wants FedCM interception, and whether `Clear-Site-Data`
+> should remove the registration. With the flag-based model, unregistration is the standard
+> `registration.unregister()` call (or the IDP removes the `acceptsFedCM` option on a subsequent
+> `register()`). `Clear-Site-Data` removes the registration the same way it removes any SW
+> registration — there is no separate "FedCM partition" to clear.
+
+### 2. Browser Dispatches `IdentityRequestEvent` to the SW
+
+When the browser needs to fetch an IDP credentialed endpoint (`accounts`, `id_assertion`,
+`disconnect`), it constructs a locked-down internal request (see
+[*UA-Direct Request Shape*](#ua-direct-request-shape) below) and dispatches an
+`identityrequest` event to the registered, opted-in SW:
 
 ```webidl
 enum IdentityRequestEndpoint {
     "accounts",
-    "id_assertion",
+    "id-assertion",
     "disconnect"
 };
 
-[Exposed=ServiceWorker]
+[Exposed=ServiceWorker, SecureContext]
 interface IdentityRequestEvent : ExtendableEvent {
     constructor(DOMString type, IdentityRequestEventInit eventInitDict);
 
     readonly attribute IdentityRequestEndpoint endpoint;
     readonly attribute Request request;
+    readonly attribute USVString rpClientId;
 
-    [RaisesException] undefined respondWith(Promise<Response> r);
+    undefined respondWith(Promise<Response> response);
+    [NewObject] Promise<Response> fetchAugmented(optional AugmentInit init = {});
 };
 
 dictionary IdentityRequestEventInit : ExtendableEventInit {
     required IdentityRequestEndpoint endpoint;
     required Request request;
+    USVString rpClientId;
+};
+
+dictionary AugmentInit {
+    HeadersInit headers;
+    AbortSignal signal;
 };
 ```
 
-**Key properties:**
-- `endpoint` — An `IdentityRequestEndpoint` enum value: `"accounts"`, `"id_assertion"`, or `"disconnect"`
-- `request` — A full `Request` object with the original URL, method, body (for POST), and `destination: "webidentity"` (which sets `Sec-Fetch-Dest: webidentity`)
-- `respondWith(promise)` — The SW provides a `Response` to the browser, same pattern as `FetchEvent.respondWith()`
+**Key members:**
 
-#### 3. SW Handles the Event
+- `endpoint` — `"accounts"`, `"id-assertion"`, or `"disconnect"`.
+- `request` — A JS `Request` *view* of the UA's privileged internal request. It exposes the URL,
+  method, and body (for POST). It does **not** expose the privileged internal slots
+  (`client = null`, opaque `origin`, `destination = "webidentity"`) — those are kept in an
+  internal `[[StoredRequest]]` slot, not visible to JS.
+- `rpClientId` — The RP's client identifier, for endpoints that need it.
+- `respondWith(promise)` — Same pattern as `FetchEvent.respondWith()`; the SW returns a `Response`
+  to the UA.
+- `fetchAugmented(init)` — A purpose-built forwarding method that fetches the *internal* request
+  (preserving all UA-set properties) with optional augmenting headers. See
+  [*Why `fetchAugmented`*](#why-fetchaugmented).
 
-```javascript
-// /idp-sw.js — IDP's Identity Handler Service Worker
+> **Note — substantial discussion in PR #815: single event vs per-endpoint events.** A reviewer
+> recommended three separate events (`accountsrequest`, `identityassertionrequest`,
+> `disconnectrequest`) rather than one `identityrequest` event discriminated by an `endpoint`
+> field. The single-event design was chosen because (a) it keeps the SW's `addEventListener` set
+> small and predictable, (b) it allows IDPs to share common framing logic across endpoints
+> (logging, augmentation, error handling) without registering three listeners, and (c) it
+> mirrors the precedent of `FetchEvent`, which is also a single event whose target / method are
+> discriminating fields. The tradeoff — that an SW receives `identityrequest` events for
+> endpoints it doesn't actually intend to handle — is mitigated by the SW's ability to inspect
+> `event.endpoint` and call `event.fetchAugmented()` (no augmentation) to forward unchanged.
+
+### 3. SW Handles the Event
+
+The recommended pattern is to call `event.fetchAugmented(...)` from `respondWith`:
+
+```js
+// /sw.js — IDP's Service Worker (opted in via acceptsFedCM: true)
 
 self.addEventListener('identityrequest', (event) => {
+  if (event.endpoint === 'id-assertion') {
+    event.respondWith((async () => {
+      const dpop = await generateDPoPProof({
+        htm: 'POST',
+        htu: event.request.url,
+        key: await getDPoPKey(),
+      });
+      // Forward UA's privileged request augmented with DPoP.
+      return event.fetchAugmented({ headers: { DPoP: dpop } });
+    })());
+    return;
+  }
+
   if (event.endpoint === 'accounts') {
-    // Add DPoP proof header to the accounts request
-    const augmented = new Request(event.request, {
-      headers: { ...event.request.headers, 'DPoP': generateDPoPProof() }
-    });
-    event.respondWith(fetch(augmented));
+    // Forward unchanged — preserves all UA-set privileged properties.
+    event.respondWith(event.fetchAugmented());
     return;
   }
 
-  if (event.endpoint === 'id_assertion') {
-    // Add DPoP proof to token request
-    const augmented = new Request(event.request, {
-      headers: { ...event.request.headers, 'DPoP': generateDPoPProof() }
-    });
-    event.respondWith(fetch(augmented));
-    return;
-  }
-
-  // For endpoints not handled, the browser falls back to normal network fetch
+  // For endpoints the SW doesn't handle, simply do nothing.
+  // The UA falls back to the normal network fetch.
 });
 ```
 
-#### 4. Fallback to Network
+### Why `fetchAugmented`?
 
-If the SW does not call `respondWith()`, rejects the promise, returns a non-OK response, or times out (default 10 seconds), the browser **transparently falls back** to a normal network fetch — as if the SW did not exist. This ensures the feature is purely additive: IDPs that opt in get SW capabilities, but failures never break the FedCM flow.
+A naive design would let the SW call `event.respondWith(fetch(event.request))`. **This does not
+work** for FedCM, because the FedCM internal request is constructed with deliberately hardened
+properties (see [*UA-Direct Request Shape*](#ua-direct-request-shape)) that the public `Request`
+constructor does not preserve:
+
+| Internal property | UA-direct value | After `fetch(event.request)` |
+| --- | --- | --- |
+| `client` | `null` | SW's settings object ❌ |
+| `origin` | opaque | IDP origin ❌ |
+| `destination` | `"webidentity"` | `""` ❌ |
+
+When these properties are lost, the network stack derives different wire headers:
+
+| Wire | UA-direct | `fetch(event.request)` |
+| --- | --- | --- |
+| `Sec-Fetch-Dest` | `webidentity` | `empty` ❌ |
+| `Sec-Fetch-Site` | `cross-site` | `same-origin` ❌ |
+| `Origin` | `null` | `https://idp.example` ❌ |
+| `Cookie` scope | `SameSite=None` only | All cookies including Lax / Strict ❌ |
+
+The IDP server cannot tell the SW-mediated request apart from a page-initiated XHR — the FedCM
+CSRF marker (`Sec-Fetch-Dest: webidentity`) is gone, and Lax / Strict cookies are now exposed.
+
+`event.fetchAugmented(init)` solves this by holding a reference to the UA's internal request
+(in an internal `[[StoredRequest]]` slot) and invoking the Fetch algorithm directly on a clone of
+it — **bypassing the `Request` constructor entirely**. The result is a request that is
+byte-for-byte identical to the UA-direct request, optionally with extra headers from the
+allowlist.
+
+#### Augmenting Header Allowlist (Block-by-Default)
+
+`AugmentInit` accepts only `headers` and `signal` — no `method`, no `body`, no `credentials`, no
+`redirect`. The trust model is "augment, not mutate."
+
+Headers passed via `init.headers` must be on the **augmenting header allowlist**:
+
+| Header | Rationale |
+| --- | --- |
+| `DPoP` | Proof-of-possession of a service-worker-held key. Primary motivating use case. [RFC 9449](https://www.rfc-editor.org/rfc/rfc9449). |
+| `Authorization` | Bearer tokens layered on top of the cookie session (MFA step-up, downstream service tokens). |
+| `Signature` | HTTP Message Signatures ([RFC 9421](https://www.rfc-editor.org/rfc/rfc9421)). |
+| `Signature-Input` | RFC 9421 metadata header accompanying `Signature`. |
+| `Content-Digest` | [RFC 9530](https://www.rfc-editor.org/rfc/rfc9530) integrity digest for request body when used with HTTP Message Signatures. |
+
+Any other header name (including `X-Request-Id`, custom `X-*` headers, etc.) causes
+`fetchAugmented()` to reject with a `TypeError`. New headers can be added to the allowlist only
+via a spec amendment that includes a security review.
+
+> **Note — substantial discussion in PR #815: block-by-default header policy.** Reviewer
+> guidance was that augmenting headers should be **allowlisted**, not denylisted, so that the
+> trust default is "any header not explicitly listed is forbidden." This forces a security
+> review whenever a new use case wants a new header, rather than relying on the spec to keep an
+> ever-growing list of forbidden names in sync with new attacks. The five headers above are the
+> use cases the spec has explicitly considered and accepted.
+
+Headers that are UA-set on the FedCM internal request (e.g., `Accept`, `Sec-Fetch-*`, `Cookie`,
+`Origin`, `Referer`) **cannot be overridden** — even if a future allowlist amendment added them
+by mistake, the algorithm's append-only rule rejects any attempt to override a UA-set header.
+
+#### Response Type Restriction
+
+`fetchAugmented()` accepts only responses whose [response type](https://fetch.spec.whatwg.org/#concept-response-type)
+is `"basic"` (same-origin) or `"default"` (UA-constructed). Responses of type `"cors"`,
+`"opaque"`, `"opaqueredirect"`, or `"error"` are rejected. This matches the UA-direct path:
+credentialed FedCM endpoints always target the IDP's own origin with `redirect mode: "error"`,
+so the response can only originate from the IDP origin.
+
+> **Note — substantial discussion in PR #815: cross-site redirects.** A reviewer raised the
+> concern that letting the SW return arbitrary responses would effectively allow cross-site
+> redirects, even though the UA-direct path uses `redirect mode: "error"` to prohibit them. The
+> response-type filter is the resolution: any response that originated from a different origin
+> (`"cors"` or `"opaque"`) is rejected, so the user agent dialog's origin assumption holds end
+> to end.
+
+### 4. Fallback to Network
+
+If the SW does not handle the event, calls `respondWith` with a rejected promise, returns a
+non-OK response, returns a response of a disallowed type, or times out (default 10 seconds),
+the browser **transparently falls back** to a normal network fetch — as if the SW did not exist
+or had not opted in. The feature is purely additive: IDPs that opt in get SW capabilities, but
+failures never break the FedCM flow.
+
+The implementation uses a "skip flag" pattern for fallback:
+
+1. If SW dispatch fails → emit console warning.
+2. Set `skip_identity_handler` flag → bypass SW on retry.
+3. Re-issue the same request via normal network fetch.
+4. Clear the flag for future requests.
+
+### UA-Direct Request Shape
+
+When the UA fetches a FedCM credentialed endpoint directly (no SW), it constructs an internal
+request with deliberately hardened properties. The same shape is preserved end-to-end by
+`fetchAugmented()`:
+
+| Property | Value | Purpose |
+| --- | --- | --- |
+| `URL` | The endpoint URL (resolved via *computing the manifest URL*) | Target the IDP's endpoint |
+| `method` | `GET` (accounts) or `POST` (id-assertion / disconnect) | Per endpoint semantics |
+| `redirect mode` | `"error"` | Prevents IDP from redirecting the credentialed fetch elsewhere |
+| `client` | `null` | No environment settings object → no ambient authority leaks |
+| `service-workers mode` | `"none"` (for the inner network fetch) | Prevents recursive SW interception of the same request |
+| `destination` | `"webidentity"` | Stamps `Sec-Fetch-Dest: webidentity` on the wire — the FedCM CSRF marker |
+| `origin` | a fresh **opaque origin** | Forces cookie layer to treat as cross-site to the IDP |
+| `Accept` header | `application/json` (accounts) or `application/x-www-form-urlencoded` (id-assertion / disconnect) | Forces request / response shape |
+| `referrer policy` | `"no-referrer"` | Prevents RP origin leakage to IDP |
+| `credentials mode` | `"include"` | Required to send the IDP session cookie |
+| `mode` | `"no-cors"` | Bypasses CORS preflight |
+
+The resulting wire request to `idp.example/accounts` (UA-direct, *or* SW-mediated via
+`fetchAugmented`):
+
+```http
+GET /accounts HTTP/1.1
+Host: idp.example
+Accept: application/json
+Cookie: sid=abc123                       ← SameSite=None cookies only
+Sec-Fetch-Dest: webidentity              ← UA-stamped, unforgeable
+Sec-Fetch-Site: cross-site
+Sec-Fetch-Mode: no-cors
+Origin: null
+```
 
 ### Selective Endpoint Policy
 
 Only credentialed authentication endpoints are dispatched to the SW:
 
 | Endpoint | SW Dispatch | Reason |
-|----------|-----------|--------|
+| --- | --- | --- |
 | `/accounts` | ✅ Yes | User account data — benefits from caching and augmentation |
-| `/token` (id_assertion) | ✅ Yes | Token generation — can use DPoP, custom logic |
+| `/token` (id-assertion) | ✅ Yes | Token generation — can use DPoP, custom logic |
 | `/disconnect` | ✅ Yes | Account management — graceful error handling |
 | `/.well-known/web-identity` | ❌ No | IDP discovery — privacy protection |
 | `/config.json` | ❌ No | Configuration — privacy protection |
 | `/client_metadata` | ❌ No | RP metadata — privacy protection |
 
-### Why a Dedicated Event (Not FetchEvent)?
+Configuration endpoints are fetched with privacy-preserving properties (`credentials: "omit"`,
+opaque origin, no referrer) and are deliberately kept out of SW scope to preserve the privacy
+boundary between RP identity and IDP cookies.
+
+### Why a Dedicated Event (Not `FetchEvent`)?
 
 | Aspect | `FetchEvent` approach | `IdentityRequestEvent` approach |
-|--------|----------------------|-------------------------------|
-| Opt-in | Implicit (any SW intercepts) | Explicit (`identity_handler` in config) |
+| --- | --- | --- |
+| Opt-in | Implicit (any SW would intercept once FedCM is in scope) | Explicit (`acceptsFedCM: true`) |
 | Scoping | SW sees ALL fetches from its origin | SW only receives identity events |
-| API surface | Generic request/response | Purpose-built: `endpoint`, `request`, `respondWith()` |
-| Browser control | Browser sets `service-workers mode` | Browser controls registration lifecycle |
-| Cleanup | SW persists until unregistered | Auto-unregistered when IDP removes config |
+| Property preservation | `fetch(event.request)` strips internal slots ❌ | `fetchAugmented()` preserves them ✅ |
+| Augmentation policy | Open (any header) | Block-by-default allowlist |
+| API surface | Generic | Purpose-built: `endpoint`, `request`, `rpClientId`, `fetchAugmented` |
 | Intent signaling | SW may not know it's a FedCM request | Clear `identityrequest` event type |
-
-The dedicated event approach provides clearer separation of concerns — the IDP explicitly declares intent in their config, and the browser manages the SW lifecycle.
 
 ## Benefits
 
 ### DPoP (Demonstration of Proof-of-Possession)
 
-The primary motivating use case. DPoP binds tokens to the specific client that requested them, preventing token theft:
+The primary motivating use case. DPoP binds tokens to the specific client that requested them,
+preventing token theft:
 
-```javascript
+```js
 self.addEventListener('identityrequest', (event) => {
-  if (event.endpoint === 'id_assertion') {
-    const dpopProof = await generateDPoPProof(event.request.url, 'POST');
-    const augmented = new Request(event.request, {
-      headers: { ...event.request.headers, 'DPoP': dpopProof }
-    });
-    event.respondWith(fetch(augmented));
+  if (event.endpoint === 'id-assertion') {
+    event.respondWith((async () => {
+      const dpop = await generateDPoPProof({
+        htm: 'POST',
+        htu: event.request.url,
+        key: await getDPoPKey(),
+      });
+      return event.fetchAugmented({ headers: { DPoP: dpop } });
+    })());
   }
 });
 ```
 
 ### Graceful Degradation During Outages
 
-```javascript
+```js
 self.addEventListener('identityrequest', (event) => {
   if (event.endpoint === 'accounts') {
-    event.respondWith(
-      fetch(event.request)
-        .then(response => {
-          if (response.ok) {
-            // Cache successful response
-            caches.open('fedcm-cache').then(c => c.put(event.request, response.clone()));
-          }
-          return response;
-        })
-        .catch(async () => {
-          // Network failed — serve stale cache
-          const cached = await caches.match(event.request);
-          if (cached) return cached;
-          throw new Error('No cached accounts available');
-        })
-    );
+    event.respondWith((async () => {
+      try {
+        const response = await event.fetchAugmented();
+        if (response.ok) {
+          const cache = await caches.open('fedcm-cache');
+          await cache.put(event.request, response.clone());
+        }
+        return response;
+      } catch {
+        const cached = await caches.match(event.request);
+        if (cached) return cached;
+        throw new Error('No cached accounts available');
+      }
+    })());
   }
 });
 ```
@@ -189,8 +422,7 @@ self.addEventListener('identityrequest', (event) => {
 
 RPs require **zero changes**. The FedCM API contract is unchanged:
 
-```javascript
-// Standard FedCM usage — works identically with or without Identity Handler
+```js
 const credential = await navigator.credentials.get({
   identity: {
     providers: [{
@@ -209,49 +441,76 @@ console.log('Token:', credential.token);
 
 This proposal does **not** enable complete offline authentication:
 
-1. Configuration endpoints (`/.well-known`, `/config.json`) are fetched **before** the SW-enabled endpoints
-2. If config fetch fails (network offline, cache expired), the entire FedCM flow fails before reaching the SW
-3. SW only helps with **partial outages** — config servers reachable, auth servers down
+1. Configuration endpoints (`/.well-known`, `/config.json`) are fetched **before** the SW-enabled
+   endpoints.
+2. If config fetch fails (network offline, cache expired), the entire FedCM flow fails before
+   reaching the SW.
+3. SW only helps with **partial outages** — config servers reachable, auth servers down.
 
-### SW Must Be Registered via Config
+### Augmentation Only, Not Mutation
 
-Unlike generic SW registration (where visiting `idp.example` is sufficient), the Identity Handler SW is registered **by the browser** when it parses the `identity_handler` field in `config.json`. This means:
-- The IDP must include `identity_handler` in their config
-- The browser manages registration and unregistration lifecycle
-- The SW is scoped specifically for identity request handling
+The SW cannot modify the request URL, method, body, redirect mode, credentials mode, or
+referrer. It can only append headers from the allowlist. IDPs that need to substantially rewrite
+requests must use generic SW interception on non-FedCM endpoints.
 
 ### Timeout Enforcement
 
-The browser enforces a timeout (default 10 seconds) on the `respondWith()` promise. If the SW does not respond in time, the browser falls back to network. This prevents slow or hung SWs from blocking authentication.
+The browser enforces a timeout (default 10 seconds) on the `respondWith()` promise. If the SW
+does not respond in time, the browser falls back to network. This prevents slow or hung SWs
+from blocking authentication.
 
 ## Privacy Considerations
 
 ### Configuration Endpoints Are Protected
 
-Configuration endpoints (`/.well-known`, `/config.json`, `/client_metadata`) are **not** dispatched to the SW for privacy reasons:
+Configuration endpoints (`/.well-known`, `/config.json`, `/client_metadata`) are **not**
+dispatched to the SW for privacy reasons:
 
-- These endpoints are fetched with privacy-preserving properties (`credentials: "omit"`, opaque origin, no referrer)
-- If intercepted, the SW could correlate user identity (via cookies from its own origin) with RP identity (from `client_metadata` URL parameters)
-- Keeping these endpoints out of SW scope preserves the privacy boundary
+- These endpoints are fetched with privacy-preserving properties (`credentials: "omit"`, opaque
+  origin, no referrer).
+- If intercepted, the SW could correlate user identity (via cookies from its own origin) with
+  RP identity (from `client_metadata` URL parameters).
+- Keeping these endpoints out of SW scope preserves the privacy boundary.
+
+### RP Encoding in Config — Substantial Discussion
+
+> **Note — substantial discussion in PR #815: RP-correlated SW endpoints.** A reviewer raised
+> the concern: if the SW (or the config it is derived from) could encode the RP identity, the
+> SW would learn the RP and the cross-site privacy boundary FedCM aims to enforce would
+> collapse. The current proposal addresses this in two ways:
+>
+> 1. The SW is registered by the IDP at the IDP origin via the standard SW registration API
+>    (`navigator.serviceWorker.register`). There is no FedCM-specific mechanism for the IDP to
+>    dynamically inject an RP-keyed SW script or config.
+> 2. The credentialed endpoints dispatched to the SW (`accounts`, `id_assertion`, `disconnect`)
+>    already have the same RP visibility on the IDP server today: `id_assertion` and
+>    `disconnect` carry the RP's `client_id` in the POST body; `accounts` carries no RP identity
+>    at all. The SW sees nothing the IDP server does not already see.
+>
+> This open thread is not fully closed — see [Open Questions](#open-questions).
 
 ### IDP Trust Model
 
-The Identity Handler SW runs at the IDP's origin and sees the same information that IDP servers already see:
-- `/accounts` (GET) — no RP identity visible (opaque origin)
-- `/token` (POST) — RP client_id in the POST body (already visible to IDP server)
-- `/disconnect` (POST) — RP client_id in the POST body (already visible to IDP server)
+The Identity Handler SW runs at the IDP's origin and sees the same information that IDP servers
+already see:
 
-No new information is exposed beyond what the IDP server already receives. The SW has the same visibility as the IDP backend.
+- `/accounts` (GET) — no RP identity visible (opaque origin).
+- `/token` (POST) — RP `client_id` in the POST body (already visible to IDP server).
+- `/disconnect` (POST) — RP `client_id` in the POST body (already visible to IDP server).
+
+No new information is exposed beyond what the IDP server already receives.
 
 ### User Consent
 
-User consent is still required before any tokens are issued. The SW cannot bypass the FedCM consent UI — it only augments the network layer between the browser and the IDP server.
+User consent is still required before any tokens are issued. The SW cannot bypass the FedCM
+consent UI — it only augments the network layer between the browser and the IDP server.
 
 ## Security Considerations
 
 ### Origin Isolation
 
-The Identity Handler SW is registered at the IDP origin and can only intercept requests destined for that origin:
+The Identity Handler SW is registered at the IDP origin and can only intercept requests destined
+for that origin:
 
 ```
 ✅ idp.example's SW intercepts: requests TO idp.example/accounts
@@ -261,44 +520,136 @@ The Identity Handler SW is registered at the IDP origin and can only intercept r
 
 Cross-origin Service Worker interception is architecturally impossible.
 
-### Sec-Fetch-Dest: webidentity
+### `Sec-Fetch-Dest: webidentity` Preserved End-to-End
 
-FedCM requests include `Sec-Fetch-Dest: webidentity`, a forbidden header that cannot be set by JavaScript. The `Request` object exposed to the SW has `destination: "webidentity"`, which the SW can **read** but cannot **set**. IDPs can validate this header server-side to confirm requests genuinely originate from the FedCM API.
+FedCM requests include `Sec-Fetch-Dest: webidentity`, a forbidden header that cannot be set by
+JavaScript. When the SW forwards via `event.fetchAugmented()`, this header is preserved on the
+wire because the algorithm operates on the UA's internal request rather than constructing a new
+JS `Request`. IDPs validate this header server-side to confirm requests genuinely originate from
+the FedCM API.
+
+### Cookie Scope Preserved
+
+Because `fetchAugmented` preserves the internal request's `client = null` and opaque `origin`,
+the Fetch *determine the same-site mode* algorithm continues to return `unset-or-less` for the
+forwarded request → only `SameSite=None` cookies are eligible. `SameSite=Lax` and
+`SameSite=Strict` cookies remain protected.
 
 ### Redirect Prevention
 
-FedCM requests use `redirect mode: "error"` — the SW cannot redirect requests to different URLs. This prevents token theft via redirect attacks.
+FedCM requests use `redirect mode: "error"` — the SW cannot redirect requests to different URLs
+via `fetchAugmented`. In addition, the response-type filter (see
+[*Response Type Restriction*](#response-type-restriction)) rejects any response whose origin
+differs from the IDP's, so the SW cannot launder a cross-origin response back into the FedCM
+flow either.
+
+### Synthetic Event Defense
+
+`fetchAugmented` checks an internal `[[StoredRequest]]` slot that is set only when the UA's
+FedCM machinery dispatches the event. If JS code synthesizes an `IdentityRequestEvent` via its
+constructor and dispatches it, `[[StoredRequest]]` is null and `fetchAugmented` rejects with a
+`TypeError`.
 
 ### Robust Fallback
 
-The implementation uses a "skip flag" pattern for fallback:
-1. If SW dispatch fails → emit console warning
-2. Set `skip_identity_handler` flag → bypass SW on retry
-3. Re-issue the same request via normal network fetch
-4. Clear the flag for future requests
-
-This ensures that SW failures never block authentication — the flow degrades gracefully to the non-SW path.
+SW failures (no listener, rejection, non-OK response, disallowed response type, timeout) trigger
+a transparent fallback to the UA-direct network fetch, with a console warning. SW bugs cannot
+block authentication.
 
 ## Developer Experience
 
 **IDP developers** opt in by:
-1. Adding `"identity_handler": {"service_worker": "/sw.js"}` to their FedCM config
-2. Implementing an `identityrequest` event handler in their SW
-3. Using standard web APIs (Fetch, Cache, Crypto) within the handler
+
+1. Adding `acceptsFedCM: true` to their existing `navigator.serviceWorker.register(...)` call.
+2. Implementing an `identityrequest` event handler in their SW.
+3. Calling `event.fetchAugmented(...)` (optionally with allowlisted headers) and passing the
+   result to `event.respondWith(...)`.
 
 **RP developers**: No changes required. Completely transparent.
 
 **Debugging**: Console warnings are emitted when the SW fails:
+
 - "FedCM: No identity handler service worker registration found for the provider. Falling back to network."
+- "FedCM: The matched registration is not opted in via acceptsFedCM. Falling back to network."
 - "FedCM: The identity handler service worker has no active version. Falling back to network."
 - "FedCM: The identity handler service worker failed to start. Falling back to network."
 - "FedCM: The identity handler response had a non-ok status (NNN). Falling back to network."
+- "FedCM: Header \"X-Foo\" is not on the augmenting header allowlist."
+
+## Alternatives Considered
+
+### Config-Based Browser-Managed Registration (rejected)
+
+Earlier drafts proposed an `identity_handler.service_worker` field in `config.json` that the
+browser would parse and use to register the SW automatically. Rejected for the reasons listed
+under [*SW Registration Model*](#sw-registration-model): unclear lifecycle ownership, novel
+scope semantics, and divergence from developer expectations.
+
+### Separate FedCM-Only SW Registry (deferred)
+
+A stronger isolation option is to create a separate registration registry (`registerForFedCM`)
+so that FedCM SWs and general SWs are entirely distinct objects. This is more invasive (new IDL
+surface, new lifecycle algorithms, ~10 cross-cutting interactions with `Clients`,
+`BroadcastChannel`, push, etc.) and forces IDPs to manage two SWs with shared-state
+coordination.
+
+The opt-in flag (Option A) addresses the same two threats the reviewer raised — pre-existing SW
+accidental interception, and cross-feature misuse of FedCM SWs — at a fraction of the cost. The
+flag-based model is also forward-compatible: if a future threat materializes that the flag
+doesn't cover, the spec can evolve toward registry separation. The reverse migration (from
+registry separation back to a flag) is much harder once IDPs are running two SWs.
+
+### Separate FedCM Storage Partition (rejected)
+
+A maximal isolation option (separate registry **plus** a separate storage partition keyed by
+`(storage key, FedCM)`) was considered. Rejected because:
+
+- IDPs cannot share DPoP keys, session caches, or user preferences between the general and FedCM
+  SWs without runtime `postMessage` choreography.
+- The threats it addresses (compromised general SW reading FedCM state) require attacker control
+  of SW code, which a storage partition does not actually prevent.
+- It would require coordination with `[[STORAGE]]`, `[[FETCH]]`, and `[[COOKIES]]` spec editors.
+
+### `fetch(event.request)` from a Generic `FetchEvent` (rejected)
+
+Allowing FedCM requests to flow through the standard `FetchEvent` pathway is the simplest
+possible design but loses every UA-set privileged property as soon as the SW does
+`fetch(event.request)` — see [*Why `fetchAugmented`*](#why-fetchaugmented). The IDP server can
+no longer tell SW-mediated FedCM requests from page-initiated XHRs, the CSRF marker
+(`Sec-Fetch-Dest: webidentity`) is gone, and `SameSite=Lax` / `Strict` cookies leak. This is
+the central reason a dedicated event and dedicated forwarding method are needed.
+
+## Open Questions
+
+> **Note — substantial discussion in PR #815.** The following questions had non-trivial threads
+> in PR review. They are listed here so the explainer can be discussed independently of the
+> spec PR.
+
+1. **Unregistration on logout.** Should the spec require / recommend that IDPs unregister the
+   FedCM-opted SW on logout, or is the standard SW lifecycle sufficient? (Reviewer:
+   yoshisatoyanagisawa.)
+2. **Per-endpoint events vs single event.** Should the design be split into three events
+   (`accountsrequest`, `identityassertionrequest`, `disconnectrequest`) for clarity? (Reviewer:
+   yoshisatoyanagisawa; current design: single event with `endpoint` field.)
+3. **RP-correlated SW endpoints.** Are there any indirect paths by which an IDP could
+   dynamically derive an RP-keyed SW script or config (e.g., via the
+   `client_metadata` exchange)? (Reviewer: npm1.)
+4. **Augmenting header allowlist growth.** What is the threshold / process for adding new
+   headers? Reviewer-recommended block-by-default keeps the list small, but the spec needs an
+   explicit amendment process. (Reviewer: yoshisatoyanagisawa — block-by-default adopted.)
+5. **DevTools UX.** All SW-related features need a story for DevTools' Application > Service
+   Workers panel. The opt-in flag should surface visibly so IDP developers can verify they
+   opted in correctly.
+6. **Naming.** `acceptsFedCM` vs `acceptsIdentityRequest` vs `fedcmEnabled` — bikeshed.
 
 ## References
 
 - [FedCM Specification](https://fedidcg.github.io/FedCM/)
 - [FedCM Identity Handler section](https://fedidcg.github.io/FedCM/#identity-handler)
+- [Spec PR #815 — Enabling IDP Interception in FedCM Request](https://github.com/w3c-fedid/FedCM/pull/815)
+- [GitHub Issue #80 — SW interception for FedCM](https://github.com/w3c-fedid/FedCM/issues/80)
 - [Service Worker Specification](https://w3c.github.io/ServiceWorker/)
 - [Fetch Specification](https://fetch.spec.whatwg.org/)
-- [GitHub Issue #80 — SW interception for FedCM](https://github.com/w3c-fedid/FedCM/issues/80)
 - [DPoP (RFC 9449)](https://www.rfc-editor.org/rfc/rfc9449)
+- [HTTP Message Signatures (RFC 9421)](https://www.rfc-editor.org/rfc/rfc9421)
+- [HTTP Integrity Fields (RFC 9530)](https://www.rfc-editor.org/rfc/rfc9530)

--- a/explorations/identity_handler.md
+++ b/explorations/identity_handler.md
@@ -337,22 +337,6 @@ Approaches under consideration:
 
 Whichever approach is chosen, the spec requires the same end-state: the request that hits the wire after SW forwarding is byte-for-byte equivalent to the UA-direct request (optionally with allowlisted augmenting headers added).
 
-### c) Other Areas of Active Discussion
-
-- **Single event vs per-endpoint events.** The current design uses one `identityrequest` event with an `endpoint` field. A reviewer recommended three separate events (`accountsrequest`, `identityassertionrequest`, `disconnectrequest`). The single-event design was chosen because (a) it keeps the SW's `addEventListener` set small, (b) it lets IDPs share common framing logic across endpoints, and (c) it mirrors the precedent of `FetchEvent`. Open to revisit if there is consensus the per-endpoint design is clearer.
-- **RP-correlated SW endpoints.** A reviewer raised a privacy concern that if the SW (or its registration / config) could encode the RP identity, the SW would learn the RP and the cross-site privacy boundary FedCM aims to enforce would collapse. The current proposal does not provide any FedCM-specific mechanism for the IDP to dynamically inject an RP-keyed SW; the SW sees only what the IDP server already sees today (RP `client_id` in `id_assertion` / `disconnect` POST bodies, nothing in `accounts`). Whether any indirect path (e.g., via `client_metadata`) needs additional mitigation is still being analyzed.
-- **Augmenting header allowlist.** The SW needs to be able to attach additional headers when forwarding a FedCM request (the motivating use cases are DPoP, MFA step-up via an additional `Authorization`, and request signing). The current spec text in `index.bs` does not yet define the permitted set. The companion design notes (`Q:\cr\src\docs\local\SW-interception-of-FedCM-request.md` §3.4) propose a block-by-default allowlist with the following initial entries, pending working-group review:
-
-    | Header | Rationale |
-    |---|---|
-    | `DPoP` | Proof-of-possession of a service-worker-held key. Primary motivating use case. [RFC 9449](https://www.rfc-editor.org/rfc/rfc9449). |
-    | `Authorization` | Bearer tokens layered on top of the cookie session (MFA step-up, downstream service tokens). |
-    | `Signature` | HTTP Message Signatures ([RFC 9421](https://www.rfc-editor.org/rfc/rfc9421)). |
-    | `Signature-Input` | RFC 9421 metadata header accompanying `Signature`. |
-    | `Content-Digest` | [RFC 9530](https://www.rfc-editor.org/rfc/rfc9530) integrity digest for request body when used with HTTP Message Signatures. |
-
-    The spec also needs to define an explicit amendment process for adding new headers — file an issue with the header name, use case, applicable endpoints, security analysis, and IDP-side handling guidance; editors and security reviewers vet before the list grows.
-
 ## References
 
 - [FedCM Specification](https://fedidcg.github.io/FedCM/)

--- a/explorations/identity_handler.md
+++ b/explorations/identity_handler.md
@@ -7,413 +7,179 @@ Suresh Potti (sureshpotti@microsoft.com)
 
 - https://github.com/w3c-fedid/FedCM/issues/80
 - https://github.com/w3c-fedid/FedCM/pull/815 (spec PR)
-- https://fedidcg.github.io/FedCM/#identity-handler
 
 ## Summary
 
-This document describes the **FedCM Identity Handler**, a feature that allows Identity Providers
-(IDPs) to opt their existing Service Worker into intercepting credentialed FedCM requests
-(`accounts`, `id_assertion`, `disconnect`). When opted in, the Service Worker receives a dedicated
-`IdentityRequestEvent` — distinct from `FetchEvent` — and can forward the request to the network
-using a purpose-built `fetchAugmented()` method that preserves the UA's privileged request
-properties while allowing a small, vetted set of augmenting headers (e.g., `DPoP`).
+This document describes the **FedCM Identity Handler**, a feature that allows Identity Providers (IDPs) to register a Service Worker that intercepts credentialed FedCM requests (accounts, id_assertion, disconnect). The Service Worker receives a dedicated `IdentityRequestEvent` — distinct from `FetchEvent` — providing a purpose-built, secure interception mechanism for federated identity flows.
 
 ## Status
 
-This explainer documents a **proposed addition** to the FedCM specification, tracked in
-[PR #815](https://github.com/w3c-fedid/FedCM/pull/815). The proposal introduces:
-
-1. An **opt-in flag** (`acceptsFedCM: true`) on the existing `ServiceWorkerContainer.register()`
-   call, so that only Service Workers that explicitly opt in are reachable by FedCM dispatch.
-2. A dedicated `IdentityRequestEvent` dispatched to the opted-in SW.
-3. A purpose-built `IdentityRequestEvent.fetchAugmented(init)` method that forwards the UA's
-   privileged internal request to the network while letting the SW append a small allowlist of
-   augmenting headers.
-
-> **Note — substantial discussion in PR #815.** Earlier drafts of this explainer described a
-> *config-based* registration model in which the IDP declared a Service Worker via an
-> `identity_handler` field in `config.json` and the browser managed registration / unregistration
-> lifecycle. Based on reviewer feedback on PR #815, that approach has been replaced by the
-> opt-in flag described in this document. The flag-based model keeps the SW lifecycle in the
-> hands of the IDP (via the standard Service Worker registration APIs) while still preventing
-> pre-existing SWs from accidentally intercepting FedCM events. See the section
-> *[SW Registration Model](#sw-registration-model)* for the full rationale and
-> *[Alternatives Considered](#alternatives-considered)* for the design space.
-
-**Key difference from generic SW interception:** Rather than changing the FedCM internal request's
-`service-workers mode` from `"none"` to `"all"` (which would route through the standard
-`FetchEvent` pathway and *lose* the UA-set privileged properties when the SW called
-`fetch(event.request)`), this proposal introduces a dedicated event type plus a dedicated
-forwarding method (`fetchAugmented`) that the browser dispatches only when the IDP's SW has
-explicitly opted in. This provides clearer intent signaling, tighter scoping, a purpose-built API
-surface, and — crucially — byte-for-byte preservation of the UA-direct request shape on the wire.
+This explainer documents a **proposed addition** to the FedCM specification, tracked in [PR #815](https://github.com/w3c-fedid/FedCM/pull/815). The proposal introduces a new `IdentityRequestEvent` dispatched to an IDP-controlled Service Worker for credentialed FedCM endpoints.
 
 ## Problem Statement
 
-Based on IDP feedback documented in [GitHub Issue #80](https://github.com/w3c-fedid/FedCM/issues/80),
-Identity Providers need programmable control over FedCM requests. Use cases raised include:
+Based on IDP feedback documented in [GitHub Issue #80](https://github.com/w3c-fedid/FedCM/issues/80), Identity Providers need programmable control over FedCM requests. Use cases raised include:
 
-- **Request signing (DPoP):** Add proof-of-possession assertions to prevent token theft — *"Bearer
-  tokens have an inherent problem that they can be stolen."*
-- **Multi-domain failover:** Route requests to backup servers when primary IDP infrastructure fails.
-- **Token caching during outages:** Graceful degradation when IDP servers are temporarily
-  unavailable.
-- **Geographic routing:** Direct requests to regional / sovereign identity services based on user
-  location.
-- **Legacy system integration:** Wrap non-FedCM identity services with FedCM-compatible interfaces.
+- **Request signing (DPoP):** Add proof-of-possession assertions to prevent token theft — *"Bearer tokens have an inherent problem that they can be stolen"*
+- **Multi-domain failover:** Route requests to backup servers when primary IDP infrastructure fails
+- **Token caching during outages:** Graceful degradation when IDP servers are temporarily unavailable
+- **Geographic routing:** Direct requests to regional/sovereign identity services based on user location
+- **Legacy system integration:** Wrap non-FedCM identity services with FedCM-compatible interfaces
 
-Currently, FedCM internal requests have `service-workers mode: "none"`, so SW interception is
-impossible — IDPs cannot leverage these programmable capabilities.
+Currently, FedCM requests bypass Service Workers entirely (`service-workers mode: "none"`), preventing IDPs from leveraging these programmable capabilities.
 
 ## Proposed Solution
 
-### 1. IDP Opts Its Service Worker Into FedCM
+### How It Works
 
-The IDP registers its Service Worker using the standard
-[`ServiceWorkerContainer.register()`](https://w3c.github.io/ServiceWorker/#dom-serviceworkercontainer-register)
-API and passes a new `acceptsFedCM` option:
+#### 1. IDP Registers a Service Worker for FedCM
 
-```js
-navigator.serviceWorker.register('/sw.js', {
-  scope: '/',
-  acceptsFedCM: true   // ← opts this SW into FedCM dispatch
-});
-```
+The IDP makes its Service Worker available to the FedCM dispatch path. The Service Worker is hosted at the IDP origin and only sees `identityrequest` events when it has explicitly indicated that it is intended to handle them.
 
-**Spec change in summary:**
+The precise registration surface — how the IDP signals that intent to the user agent — is an open design question. See [Open Design Discussions §a](#a-service-worker-registration) for the options under consideration.
 
-- A new boolean `acceptsFedCM` field on `RegistrationOptions` (defaults to `false`).
-- A new step in the `dispatch identity handler` algorithm: after `Match Service Worker
-  Registration`, if the registration's `acceptsFedCM` is `false`, return null (no SW interception).
+#### 2. Browser Dispatches `IdentityRequestEvent` to the SW
 
-A Service Worker without `acceptsFedCM: true` is **invisible** to FedCM dispatch — even if it
-adds an `identityrequest` event listener, the UA will never dispatch to it. This preserves the
-existing behavior of every SW deployed today.
-
-> **Note — substantial discussion in PR #815: registration isolation.** Reviewer feedback raised
-> the concern that pre-existing SWs (e.g., deployed for caching, push, offline) should not
-> accidentally be invoked for FedCM, and that FedCM-purposed SWs should not be misused by other
-> platform features that look up the same registration. The opt-in flag addresses both concerns
-> at minimal spec and IDP cost. Stronger forms of isolation (separate FedCM-only registration
-> registry, or even a separate storage partition) were considered and are documented under
-> [Alternatives Considered](#alternatives-considered).
-
-### SW Registration Model
-
-The Identity Handler SW is registered the same way any SW is registered: from a page on the IDP
-origin, via `navigator.serviceWorker.register(...)`. The only addition is the `acceptsFedCM`
-option.
-
-This is a deliberate change from earlier drafts, which proposed that the browser register the SW
-automatically based on an `identity_handler` field in `config.json`. The browser-managed model
-was rejected because:
-
-1. **Lifecycle ownership is unclear.** The standard SW lifecycle (install / activate / update /
-   unregister) is owned by the page that registered the SW. A browser-injected registration with
-   no owning page creates novel lifecycle questions (when is it updated? what triggers
-   `updatefound`? how does it interact with `Clear-Site-Data`?).
-2. **Scope semantics differ.** SW scope is usually derived from the registering script's URL.
-   A config-driven registration has no obvious natural scope.
-3. **Developer expectations diverge.** SWs registered outside of `navigator.serviceWorker` do not
-   appear in `getRegistrations()` and are not visible in DevTools' Service Workers panel without
-   special handling. The flag-based model "just works" with existing tooling.
-
-> **Note — substantial discussion in PR #815: unregistration.** Reviewers asked how the SW gets
-> unregistered when the IDP no longer wants FedCM interception, and whether `Clear-Site-Data`
-> should remove the registration. With the flag-based model, unregistration is the standard
-> `registration.unregister()` call (or the IDP removes the `acceptsFedCM` option on a subsequent
-> `register()`). `Clear-Site-Data` removes the registration the same way it removes any SW
-> registration — there is no separate "FedCM partition" to clear.
-
-### 2. Browser Dispatches `IdentityRequestEvent` to the SW
-
-When the browser needs to fetch an IDP credentialed endpoint (`accounts`, `id_assertion`,
-`disconnect`), it constructs a locked-down internal request (see
-[*UA-Direct Request Shape*](#ua-direct-request-shape) below) and dispatches an
-`identityrequest` event to the registered, opted-in SW:
+When the browser needs to fetch an IDP endpoint (accounts, token, disconnect), it first dispatches an `IdentityRequestEvent` to the registered SW:
 
 ```webidl
 enum IdentityRequestEndpoint {
     "accounts",
-    "id-assertion",
+    "id_assertion",
     "disconnect"
 };
 
-[Exposed=ServiceWorker, SecureContext]
+[Exposed=ServiceWorker]
 interface IdentityRequestEvent : ExtendableEvent {
     constructor(DOMString type, IdentityRequestEventInit eventInitDict);
 
     readonly attribute IdentityRequestEndpoint endpoint;
     readonly attribute Request request;
-    readonly attribute USVString rpClientId;
 
-    undefined respondWith(Promise<Response> response);
-    [NewObject] Promise<Response> fetchAugmented(optional AugmentInit init = {});
+    [RaisesException] undefined respondWith(Promise<Response> r);
 };
 
 dictionary IdentityRequestEventInit : ExtendableEventInit {
     required IdentityRequestEndpoint endpoint;
     required Request request;
-    USVString rpClientId;
-};
-
-dictionary AugmentInit {
-    HeadersInit headers;
-    AbortSignal signal;
 };
 ```
 
-**Key members:**
+**Key properties:**
+- `endpoint` — An `IdentityRequestEndpoint` enum value: `"accounts"`, `"id_assertion"`, or `"disconnect"`
+- `request` — A `Request` object with the original URL, method, body (for POST), and
+- `destination: "webidentity"` (which sets `Sec-Fetch-Dest: webidentity`)
+- `respondWith(promise)` — The SW provides a `Response` to the browser, same pattern as `FetchEvent.respondWith()`
 
-- `endpoint` — `"accounts"`, `"id-assertion"`, or `"disconnect"`.
-- `request` — A JS `Request` *view* of the UA's privileged internal request. It exposes the URL,
-  method, and body (for POST). It does **not** expose the privileged internal slots
-  (`client = null`, opaque `origin`, `destination = "webidentity"`) — those are kept in an
-  internal `[[StoredRequest]]` slot, not visible to JS.
-- `rpClientId` — The RP's client identifier, for endpoints that need it.
-- `respondWith(promise)` — Same pattern as `FetchEvent.respondWith()`; the SW returns a `Response`
-  to the UA.
-- `fetchAugmented(init)` — A purpose-built forwarding method that fetches the *internal* request
-  (preserving all UA-set properties) with optional augmenting headers. See
-  [*Why `fetchAugmented`*](#why-fetchaugmented).
+#### 3. SW Handles the Event
 
-> **Note — substantial discussion in PR #815: single event vs per-endpoint events.** A reviewer
-> recommended three separate events (`accountsrequest`, `identityassertionrequest`,
-> `disconnectrequest`) rather than one `identityrequest` event discriminated by an `endpoint`
-> field. The single-event design was chosen because (a) it keeps the SW's `addEventListener` set
-> small and predictable, (b) it allows IDPs to share common framing logic across endpoints
-> (logging, augmentation, error handling) without registering three listeners, and (c) it
-> mirrors the precedent of `FetchEvent`, which is also a single event whose target / method are
-> discriminating fields. The tradeoff — that an SW receives `identityrequest` events for
-> endpoints it doesn't actually intend to handle — is mitigated by the SW's ability to inspect
-> `event.endpoint` and call `event.fetchAugmented()` (no augmentation) to forward unchanged.
-
-### 3. SW Handles the Event
-
-The recommended pattern is to call `event.fetchAugmented(...)` from `respondWith`:
-
-```js
-// /sw.js — IDP's Service Worker (opted in via acceptsFedCM: true)
+```javascript
+// /idp-sw.js — IDP's Identity Handler Service Worker
 
 self.addEventListener('identityrequest', (event) => {
-  if (event.endpoint === 'id-assertion') {
-    event.respondWith((async () => {
-      const dpop = await generateDPoPProof({
-        htm: 'POST',
-        htu: event.request.url,
-        key: await getDPoPKey(),
-      });
-      // Forward UA's privileged request augmented with DPoP.
-      return event.fetchAugmented({ headers: { DPoP: dpop } });
-    })());
-    return;
-  }
-
   if (event.endpoint === 'accounts') {
-    // Forward unchanged — preserves all UA-set privileged properties.
-    event.respondWith(event.fetchAugmented());
+    // Add DPoP proof header to the accounts request
+    const augmented = new Request(event.request, {
+      headers: { ...event.request.headers, 'DPoP': generateDPoPProof() }
+    });
+    event.respondWith(fetch(augmented));
     return;
   }
 
-  // For endpoints the SW doesn't handle, simply do nothing.
-  // The UA falls back to the normal network fetch.
+  if (event.endpoint === 'id_assertion') {
+    // Add DPoP proof to token request
+    const augmented = new Request(event.request, {
+      headers: { ...event.request.headers, 'DPoP': generateDPoPProof() }
+    });
+    event.respondWith(fetch(augmented));
+    return;
+  }
+
+  // For endpoints not handled, the browser falls back to normal network fetch
 });
 ```
 
-### Why `fetchAugmented`?
+#### 4. Fallback to Network
 
-A naive design would let the SW call `event.respondWith(fetch(event.request))`. **This does not
-work** for FedCM, because the FedCM internal request is constructed with deliberately hardened
-properties (see [*UA-Direct Request Shape*](#ua-direct-request-shape)) that the public `Request`
-constructor does not preserve:
-
-| Internal property | UA-direct value | After `fetch(event.request)` |
-| --- | --- | --- |
-| `client` | `null` | SW's settings object ❌ |
-| `origin` | opaque | IDP origin ❌ |
-| `destination` | `"webidentity"` | `""` ❌ |
-
-When these properties are lost, the network stack derives different wire headers:
-
-| Wire | UA-direct | `fetch(event.request)` |
-| --- | --- | --- |
-| `Sec-Fetch-Dest` | `webidentity` | `empty` ❌ |
-| `Sec-Fetch-Site` | `cross-site` | `same-origin` ❌ |
-| `Origin` | `null` | `https://idp.example` ❌ |
-| `Cookie` scope | `SameSite=None` only | All cookies including Lax / Strict ❌ |
-
-The IDP server cannot tell the SW-mediated request apart from a page-initiated XHR — the FedCM
-CSRF marker (`Sec-Fetch-Dest: webidentity`) is gone, and Lax / Strict cookies are now exposed.
-
-`event.fetchAugmented(init)` solves this by holding a reference to the UA's internal request
-(in an internal `[[StoredRequest]]` slot) and invoking the Fetch algorithm directly on a clone of
-it — **bypassing the `Request` constructor entirely**. The result is a request that is
-byte-for-byte identical to the UA-direct request, optionally with extra headers from the
-allowlist.
-
-#### Augmenting Header Allowlist (Block-by-Default)
-
-`AugmentInit` accepts only `headers` and `signal` — no `method`, no `body`, no `credentials`, no
-`redirect`. The trust model is "augment, not mutate."
-
-Headers passed via `init.headers` must be on the **augmenting header allowlist**:
-
-| Header | Rationale |
-| --- | --- |
-| `DPoP` | Proof-of-possession of a service-worker-held key. Primary motivating use case. [RFC 9449](https://www.rfc-editor.org/rfc/rfc9449). |
-| `Authorization` | Bearer tokens layered on top of the cookie session (MFA step-up, downstream service tokens). |
-| `Signature` | HTTP Message Signatures ([RFC 9421](https://www.rfc-editor.org/rfc/rfc9421)). |
-| `Signature-Input` | RFC 9421 metadata header accompanying `Signature`. |
-| `Content-Digest` | [RFC 9530](https://www.rfc-editor.org/rfc/rfc9530) integrity digest for request body when used with HTTP Message Signatures. |
-
-Any other header name (including `X-Request-Id`, custom `X-*` headers, etc.) causes
-`fetchAugmented()` to reject with a `TypeError`. New headers can be added to the allowlist only
-via a spec amendment that includes a security review.
-
-> **Note — substantial discussion in PR #815: block-by-default header policy.** Reviewer
-> guidance was that augmenting headers should be **allowlisted**, not denylisted, so that the
-> trust default is "any header not explicitly listed is forbidden." This forces a security
-> review whenever a new use case wants a new header, rather than relying on the spec to keep an
-> ever-growing list of forbidden names in sync with new attacks. The five headers above are the
-> use cases the spec has explicitly considered and accepted.
-
-Headers that are UA-set on the FedCM internal request (e.g., `Accept`, `Sec-Fetch-*`, `Cookie`,
-`Origin`, `Referer`) **cannot be overridden** — even if a future allowlist amendment added them
-by mistake, the algorithm's append-only rule rejects any attempt to override a UA-set header.
-
-#### Response Type Restriction
-
-`fetchAugmented()` accepts only responses whose [response type](https://fetch.spec.whatwg.org/#concept-response-type)
-is `"basic"` (same-origin) or `"default"` (UA-constructed). Responses of type `"cors"`,
-`"opaque"`, `"opaqueredirect"`, or `"error"` are rejected. This matches the UA-direct path:
-credentialed FedCM endpoints always target the IDP's own origin with `redirect mode: "error"`,
-so the response can only originate from the IDP origin.
-
-> **Note — substantial discussion in PR #815: cross-site redirects.** A reviewer raised the
-> concern that letting the SW return arbitrary responses would effectively allow cross-site
-> redirects, even though the UA-direct path uses `redirect mode: "error"` to prohibit them. The
-> response-type filter is the resolution: any response that originated from a different origin
-> (`"cors"` or `"opaque"`) is rejected, so the user agent dialog's origin assumption holds end
-> to end.
-
-### 4. Fallback to Network
-
-If the SW does not handle the event, calls `respondWith` with a rejected promise, returns a
-non-OK response, returns a response of a disallowed type, or times out (default 10 seconds),
-the browser **transparently falls back** to a normal network fetch — as if the SW did not exist
-or had not opted in. The feature is purely additive: IDPs that opt in get SW capabilities, but
-failures never break the FedCM flow.
-
-The implementation uses a "skip flag" pattern for fallback:
-
-1. If SW dispatch fails → emit console warning.
-2. Set `skip_identity_handler` flag → bypass SW on retry.
-3. Re-issue the same request via normal network fetch.
-4. Clear the flag for future requests.
-
-### UA-Direct Request Shape
-
-When the UA fetches a FedCM credentialed endpoint directly (no SW), it constructs an internal
-request with deliberately hardened properties. The same shape is preserved end-to-end by
-`fetchAugmented()`:
-
-| Property | Value | Purpose |
-| --- | --- | --- |
-| `URL` | The endpoint URL (resolved via *computing the manifest URL*) | Target the IDP's endpoint |
-| `method` | `GET` (accounts) or `POST` (id-assertion / disconnect) | Per endpoint semantics |
-| `redirect mode` | `"error"` | Prevents IDP from redirecting the credentialed fetch elsewhere |
-| `client` | `null` | No environment settings object → no ambient authority leaks |
-| `service-workers mode` | `"none"` (for the inner network fetch) | Prevents recursive SW interception of the same request |
-| `destination` | `"webidentity"` | Stamps `Sec-Fetch-Dest: webidentity` on the wire — the FedCM CSRF marker |
-| `origin` | a fresh **opaque origin** | Forces cookie layer to treat as cross-site to the IDP |
-| `Accept` header | `application/json` (accounts) or `application/x-www-form-urlencoded` (id-assertion / disconnect) | Forces request / response shape |
-| `referrer policy` | `"no-referrer"` | Prevents RP origin leakage to IDP |
-| `credentials mode` | `"include"` | Required to send the IDP session cookie |
-| `mode` | `"no-cors"` | Bypasses CORS preflight |
-
-The resulting wire request to `idp.example/accounts` (UA-direct, *or* SW-mediated via
-`fetchAugmented`):
-
-```http
-GET /accounts HTTP/1.1
-Host: idp.example
-Accept: application/json
-Cookie: sid=abc123                       ← SameSite=None cookies only
-Sec-Fetch-Dest: webidentity              ← UA-stamped, unforgeable
-Sec-Fetch-Site: cross-site
-Sec-Fetch-Mode: no-cors
-Origin: null
-```
+If the SW does not call `respondWith()`, rejects the promise, returns a non-OK response, returns a response of a disallowed type, or times out (default 10 seconds), the browser **transparently falls back** to a normal network fetch — as if the SW did not exist. This ensures the feature is purely additive: IDPs that opt in get SW capabilities, but failures never break the FedCM flow.
 
 ### Selective Endpoint Policy
 
 Only credentialed authentication endpoints are dispatched to the SW:
 
 | Endpoint | SW Dispatch | Reason |
-| --- | --- | --- |
+|----------|-----------|--------|
 | `/accounts` | ✅ Yes | User account data — benefits from caching and augmentation |
-| `/token` (id-assertion) | ✅ Yes | Token generation — can use DPoP, custom logic |
+| `/token` (id_assertion) | ✅ Yes | Token generation — can use DPoP, custom logic |
 | `/disconnect` | ✅ Yes | Account management — graceful error handling |
 | `/.well-known/web-identity` | ❌ No | IDP discovery — privacy protection |
 | `/config.json` | ❌ No | Configuration — privacy protection |
 | `/client_metadata` | ❌ No | RP metadata — privacy protection |
 
-Configuration endpoints are fetched with privacy-preserving properties (`credentials: "omit"`,
-opaque origin, no referrer) and are deliberately kept out of SW scope to preserve the privacy
-boundary between RP identity and IDP cookies.
+### Augmenting Headers
 
-### Why a Dedicated Event (Not `FetchEvent`)?
+When the SW forwards a FedCM request, it may attach additional headers (e.g., a `DPoP` proof).
+Headers UA-set on the FedCM internal request (`Accept`, `Sec-Fetch-*`, `Cookie`, `Origin`,
+`Referer`) must **not** be overridden by the SW.
+
+The exact set of header names the SW is permitted to add, and the process for growing that
+set, is still being worked out — see [Open Design Discussions §c](#c-other-areas-of-active-discussion).
+
+### Response Type Restriction
+
+The `Response` returned to `respondWith` must have a [response type](https://fetch.spec.whatwg.org/#concept-response-type) of `"basic"` (the response came from a same-origin fetch — i.e., from the IDP's own network endpoint) or `"default"` (the SW constructed the response directly, e.g., via `new Response(...)`, rather than fetching it). Responses of type `"cors"`, `"opaque"`, `"opaqueredirect"`, or `"error"` are rejected. This ensures the response can only originate from the IDP's own origin (or from same-origin SW code), matching the UA-direct path which uses `redirect mode: "error"` on requests whose URL targets the IDP.
+
+### Why a Dedicated Event (Not FetchEvent)?
 
 | Aspect | `FetchEvent` approach | `IdentityRequestEvent` approach |
-| --- | --- | --- |
-| Opt-in | Implicit (any SW would intercept once FedCM is in scope) | Explicit (`acceptsFedCM: true`) |
+|--------|----------------------|-------------------------------|
+| Opt-in | Implicit (any SW intercepts) | Explicit (IDP-controlled opt-in) |
 | Scoping | SW sees ALL fetches from its origin | SW only receives identity events |
-| Property preservation | `fetch(event.request)` strips internal slots ❌ | `fetchAugmented()` preserves them ✅ |
+| API surface | Generic request/response | Purpose-built: `endpoint`, `request`, `respondWith()` |
 | Augmentation policy | Open (any header) | Block-by-default allowlist |
-| API surface | Generic | Purpose-built: `endpoint`, `request`, `rpClientId`, `fetchAugmented` |
 | Intent signaling | SW may not know it's a FedCM request | Clear `identityrequest` event type |
+
+The dedicated event approach provides clearer separation of concerns — the IDP explicitly opts in, and the SW receives a purpose-built event for identity flows.
 
 ## Benefits
 
 ### DPoP (Demonstration of Proof-of-Possession)
 
-The primary motivating use case. DPoP binds tokens to the specific client that requested them,
-preventing token theft:
+The primary motivating use case. DPoP binds tokens to the specific client that requested them, preventing token theft:
 
-```js
+```javascript
 self.addEventListener('identityrequest', (event) => {
-  if (event.endpoint === 'id-assertion') {
-    event.respondWith((async () => {
-      const dpop = await generateDPoPProof({
-        htm: 'POST',
-        htu: event.request.url,
-        key: await getDPoPKey(),
-      });
-      return event.fetchAugmented({ headers: { DPoP: dpop } });
-    })());
+  if (event.endpoint === 'id_assertion') {
+    const dpopProof = await generateDPoPProof(event.request.url, 'POST');
+    const augmented = new Request(event.request, {
+      headers: { ...event.request.headers, 'DPoP': dpopProof }
+    });
+    event.respondWith(fetch(augmented));
   }
 });
 ```
 
 ### Graceful Degradation During Outages
 
-```js
+```javascript
 self.addEventListener('identityrequest', (event) => {
   if (event.endpoint === 'accounts') {
-    event.respondWith((async () => {
-      try {
-        const response = await event.fetchAugmented();
-        if (response.ok) {
-          const cache = await caches.open('fedcm-cache');
-          await cache.put(event.request, response.clone());
-        }
-        return response;
-      } catch {
-        const cached = await caches.match(event.request);
-        if (cached) return cached;
-        throw new Error('No cached accounts available');
-      }
-    })());
+    event.respondWith(
+      fetch(event.request)
+        .then(response => {
+          if (response.ok) {
+            // Cache successful response
+            caches.open('fedcm-cache').then(c => c.put(event.request, response.clone()));
+          }
+          return response;
+        })
+        .catch(async () => {
+          // Network failed — serve stale cache
+          const cached = await caches.match(event.request);
+          if (cached) return cached;
+          throw new Error('No cached accounts available');
+        })
+    );
   }
 });
 ```
@@ -422,7 +188,8 @@ self.addEventListener('identityrequest', (event) => {
 
 RPs require **zero changes**. The FedCM API contract is unchanged:
 
-```js
+```javascript
+// Standard FedCM usage — works identically with or without Identity Handler
 const credential = await navigator.credentials.get({
   identity: {
     providers: [{
@@ -435,82 +202,34 @@ const credential = await navigator.credentials.get({
 console.log('Token:', credential.token);
 ```
 
-## Limitations
-
-### No Complete Offline Authentication
-
-This proposal does **not** enable complete offline authentication:
-
-1. Configuration endpoints (`/.well-known`, `/config.json`) are fetched **before** the SW-enabled
-   endpoints.
-2. If config fetch fails (network offline, cache expired), the entire FedCM flow fails before
-   reaching the SW.
-3. SW only helps with **partial outages** — config servers reachable, auth servers down.
-
-### Augmentation Only, Not Mutation
-
-The SW cannot modify the request URL, method, body, redirect mode, credentials mode, or
-referrer. It can only append headers from the allowlist. IDPs that need to substantially rewrite
-requests must use generic SW interception on non-FedCM endpoints.
-
-### Timeout Enforcement
-
-The browser enforces a timeout (default 10 seconds) on the `respondWith()` promise. If the SW
-does not respond in time, the browser falls back to network. This prevents slow or hung SWs
-from blocking authentication.
-
 ## Privacy Considerations
 
 ### Configuration Endpoints Are Protected
 
-Configuration endpoints (`/.well-known`, `/config.json`, `/client_metadata`) are **not**
-dispatched to the SW for privacy reasons:
+Configuration endpoints (`/.well-known`, `/config.json`, `/client_metadata`) are **not** dispatched to the SW for privacy reasons:
 
-- These endpoints are fetched with privacy-preserving properties (`credentials: "omit"`, opaque
-  origin, no referrer).
-- If intercepted, the SW could correlate user identity (via cookies from its own origin) with
-  RP identity (from `client_metadata` URL parameters).
-- Keeping these endpoints out of SW scope preserves the privacy boundary.
-
-### RP Encoding in Config — Substantial Discussion
-
-> **Note — substantial discussion in PR #815: RP-correlated SW endpoints.** A reviewer raised
-> the concern: if the SW (or the config it is derived from) could encode the RP identity, the
-> SW would learn the RP and the cross-site privacy boundary FedCM aims to enforce would
-> collapse. The current proposal addresses this in two ways:
->
-> 1. The SW is registered by the IDP at the IDP origin via the standard SW registration API
->    (`navigator.serviceWorker.register`). There is no FedCM-specific mechanism for the IDP to
->    dynamically inject an RP-keyed SW script or config.
-> 2. The credentialed endpoints dispatched to the SW (`accounts`, `id_assertion`, `disconnect`)
->    already have the same RP visibility on the IDP server today: `id_assertion` and
->    `disconnect` carry the RP's `client_id` in the POST body; `accounts` carries no RP identity
->    at all. The SW sees nothing the IDP server does not already see.
->
-> This open thread is not fully closed — see [Open Questions](#open-questions).
+- These endpoints are fetched with privacy-preserving properties (`credentials: "omit"`, opaque origin, no referrer)
+- If intercepted, the SW could correlate user identity (via cookies from its own origin) with RP identity (from `client_metadata` URL parameters)
+- Keeping these endpoints out of SW scope preserves the privacy boundary
 
 ### IDP Trust Model
 
-The Identity Handler SW runs at the IDP's origin and sees the same information that IDP servers
-already see:
+The Identity Handler SW runs at the IDP's origin and sees the same information that IDP servers already see:
+- `/accounts` (GET) — no RP identity visible (opaque origin)
+- `/token` (POST) — RP client_id in the POST body (already visible to IDP server)
+- `/disconnect` (POST) — RP client_id in the POST body (already visible to IDP server)
 
-- `/accounts` (GET) — no RP identity visible (opaque origin).
-- `/token` (POST) — RP `client_id` in the POST body (already visible to IDP server).
-- `/disconnect` (POST) — RP `client_id` in the POST body (already visible to IDP server).
-
-No new information is exposed beyond what the IDP server already receives.
+No new information is exposed beyond what the IDP server already receives. The SW has the same visibility as the IDP backend.
 
 ### User Consent
 
-User consent is still required before any tokens are issued. The SW cannot bypass the FedCM
-consent UI — it only augments the network layer between the browser and the IDP server.
+User consent is still required before any tokens are issued. The SW cannot bypass the FedCM consent UI — it only augments the network layer between the browser and the IDP server.
 
 ## Security Considerations
 
 ### Origin Isolation
 
-The Identity Handler SW is registered at the IDP origin and can only intercept requests destined
-for that origin:
+The Identity Handler SW is registered at the IDP origin and can only intercept requests destined for that origin:
 
 ```
 ✅ idp.example's SW intercepts: requests TO idp.example/accounts
@@ -520,127 +239,119 @@ for that origin:
 
 Cross-origin Service Worker interception is architecturally impossible.
 
-### `Sec-Fetch-Dest: webidentity` Preserved End-to-End
+### Sec-Fetch-Dest: webidentity
 
-FedCM requests include `Sec-Fetch-Dest: webidentity`, a forbidden header that cannot be set by
-JavaScript. When the SW forwards via `event.fetchAugmented()`, this header is preserved on the
-wire because the algorithm operates on the UA's internal request rather than constructing a new
-JS `Request`. IDPs validate this header server-side to confirm requests genuinely originate from
-the FedCM API.
+FedCM requests include `Sec-Fetch-Dest: webidentity`, a forbidden header that cannot be set by JavaScript. The `Request` object exposed to the SW has `destination: "webidentity"`, which the SW can **read** but cannot **set**. IDPs can validate this header server-side to confirm requests genuinely originate from the FedCM API.
 
-### Cookie Scope Preserved
-
-Because `fetchAugmented` preserves the internal request's `client = null` and opaque `origin`,
-the Fetch *determine the same-site mode* algorithm continues to return `unset-or-less` for the
-forwarded request → only `SameSite=None` cookies are eligible. `SameSite=Lax` and
-`SameSite=Strict` cookies remain protected.
+> The UA sets a number of internal fields on the FedCM request (`client`, `origin`, `destination`, `redirect mode`, `credentials mode`, `referrer policy`, `mode`, etc.) that together determine the on-the-wire shape — including `Sec-Fetch-Dest: webidentity`, the cookie scope (`SameSite=None`-only), and the value of the `Origin:` header. These fields are expected to remain intact end-to-end. However, when the SW forwards the request via `fetch(event.request)`, some of these fields may get reset as the request passes through the public `Request` constructor / Fetch algorithm, which can change the on-the-wire behavior. How the spec preserves these fields across SW forwarding is an open design question — see [Open Design Discussions §b](#b-keeping-lock-down-properties-intact-when-fetch-is-called-from-the-sw).
 
 ### Redirect Prevention
 
-FedCM requests use `redirect mode: "error"` — the SW cannot redirect requests to different URLs
-via `fetchAugmented`. In addition, the response-type filter (see
-[*Response Type Restriction*](#response-type-restriction)) rejects any response whose origin
-differs from the IDP's, so the SW cannot launder a cross-origin response back into the FedCM
-flow either.
-
-### Synthetic Event Defense
-
-`fetchAugmented` checks an internal `[[StoredRequest]]` slot that is set only when the UA's
-FedCM machinery dispatches the event. If JS code synthesizes an `IdentityRequestEvent` via its
-constructor and dispatches it, `[[StoredRequest]]` is null and `fetchAugmented` rejects with a
-`TypeError`.
+FedCM requests use `redirect mode: "error"` — the SW cannot redirect requests to different URLs. In addition, the response-type filter rejects any response whose origin differs from the IDP's, so the SW cannot launder a cross-origin response back into the FedCM flow either.
 
 ### Robust Fallback
 
-SW failures (no listener, rejection, non-OK response, disallowed response type, timeout) trigger
-a transparent fallback to the UA-direct network fetch, with a console warning. SW bugs cannot
-block authentication.
+The implementation uses a "skip flag" pattern for fallback:
+1. If SW dispatch fails → emit console warning
+2. Set `skip_identity_handler` flag → bypass SW on retry
+3. Re-issue the same request via normal network fetch
+4. Clear the flag for future requests
+
+This ensures that SW failures never block authentication — the flow degrades gracefully to the non-SW path.
 
 ## Developer Experience
 
 **IDP developers** opt in by:
-
-1. Adding `acceptsFedCM: true` to their existing `navigator.serviceWorker.register(...)` call.
-2. Implementing an `identityrequest` event handler in their SW.
-3. Calling `event.fetchAugmented(...)` (optionally with allowlisted headers) and passing the
-   result to `event.respondWith(...)`.
+1. Registering a Service Worker that handles FedCM (mechanism under discussion — see [Open Design Discussions §a](#a-service-worker-registration))
+2. Implementing an `identityrequest` event handler in their SW
+3. Using standard web APIs (Fetch, Cache, Crypto) within the handler, subject to the augmenting header allowlist
 
 **RP developers**: No changes required. Completely transparent.
 
 **Debugging**: Console warnings are emitted when the SW fails:
-
 - "FedCM: No identity handler service worker registration found for the provider. Falling back to network."
-- "FedCM: The matched registration is not opted in via acceptsFedCM. Falling back to network."
 - "FedCM: The identity handler service worker has no active version. Falling back to network."
 - "FedCM: The identity handler service worker failed to start. Falling back to network."
 - "FedCM: The identity handler response had a non-ok status (NNN). Falling back to network."
-- "FedCM: Header \"X-Foo\" is not on the augmenting header allowlist."
 
-## Alternatives Considered
+## Open Design Discussions
 
-### Config-Based Browser-Managed Registration (rejected)
+The following design questions are still being worked out in [PR #815](https://github.com/w3c-fedid/FedCM/pull/815). They are recorded here so the explainer can be discussed independently of the spec text.
 
-Earlier drafts proposed an `identity_handler.service_worker` field in `config.json` that the
-browser would parse and use to register the SW automatically. Rejected for the reasons listed
-under [*SW Registration Model*](#sw-registration-model): unclear lifecycle ownership, novel
-scope semantics, and divergence from developer expectations.
+### a) Service Worker Registration
 
-### Separate FedCM-Only SW Registry (deferred)
+How does an IDP register a Service Worker for FedCM, and how does the UA know which registration to dispatch `identityrequest` events to?
 
-A stronger isolation option is to create a separate registration registry (`registerForFedCM`)
-so that FedCM SWs and general SWs are entirely distinct objects. This is more invasive (new IDL
-surface, new lifecycle algorithms, ~10 cross-cutting interactions with `Clients`,
-`BroadcastChannel`, push, etc.) and forces IDPs to manage two SWs with shared-state
-coordination.
+Options under consideration include:
 
-The opt-in flag (Option A) addresses the same two threats the reviewer raised — pre-existing SW
-accidental interception, and cross-feature misuse of FedCM SWs — at a fraction of the cost. The
-flag-based model is also forward-compatible: if a future threat materializes that the flag
-doesn't cover, the spec can evolve toward registry separation. The reverse migration (from
-registry separation back to a flag) is much harder once IDPs are running two SWs.
+- **Opt-in flag on the existing registration.** The IDP registers its SW with the standard `navigator.serviceWorker.register(...)` API and passes a new option (e.g., `acceptsFedCM: true`) on `RegistrationOptions`. SWs without the flag are invisible to FedCM dispatch. Lowest spec and IDP cost; the SW lifecycle remains owned by the IDP page.
+- **Dedicated FedCM-only registration.** A separate `registerForFedCM(...)` API stores the FedCM SW in a parallel registry that is invisible to `getRegistration()` / `getRegistrations()`. Strongest registry-level isolation but a much larger spec surface (new IDL, new lifecycle algorithms, cross-cutting interactions with `Clients`, `BroadcastChannel`, push, etc.), and IDPs run two SWs with shared-state coordination.
+- **Separate FedCM storage partition.** Adds a separate storage partition on top of the dedicated registration. Maximal isolation, but IDPs cannot share keys / caches / preferences across the two SWs without runtime `postMessage` choreography.
+- **Dedicated manager extending `ServiceWorkerRegistration` (e.g., `registration.identity`).** Follow the architectural pattern used by features like the Periodic Background Sync API and the Notification API: extend `ServiceWorkerRegistration` with a dedicated interface — for example, `registration.identity` (an `IdentityProviderManager`). To enable FedCM interception, the IDP would call `registration.identity.register(configURL)` explicitly. This creates a one-to-one mapping between the IDP config URL and the SW registration, so functional events are only dispatched to workers that have intentionally opted in for that specific provider. (`configURL` is used here because it is the unique identifier for an `IdentityProviderConfig`.) This addresses the semantic mismatch of using the implicit `Match Service Worker Registration` algorithm for internal UA requests that lack a controlled client. It also provides a clear lifecycle: unlinking via `registration.identity.unregister(configURL)`, or implicitly through removal of the parent registration.
 
-### Separate FedCM Storage Partition (rejected)
+Reviewer concerns this section needs to resolve:
 
-A maximal isolation option (separate registry **plus** a separate storage partition keyed by
-`(storage key, FedCM)`) was considered. Rejected because:
+- Pre-existing SWs (deployed for caching, push, offline) must not accidentally be invoked for FedCM if they add an `identityrequest` listener.
+- FedCM-purposed SWs should not be reachable by unrelated platform features that look up the same registration.
+- The unregistration story should be clear (logout, `Clear-Site-Data`, IDP removal of opt-in).
 
-- IDPs cannot share DPoP keys, session caches, or user preferences between the general and FedCM
-  SWs without runtime `postMessage` choreography.
-- The threats it addresses (compromised general SW reading FedCM state) require attacker control
-  of SW code, which a storage partition does not actually prevent.
-- It would require coordination with `[[STORAGE]]`, `[[FETCH]]`, and `[[COOKIES]]` spec editors.
+Two earlier shapes were explored and have been backed out:
 
-### `fetch(event.request)` from a Generic `FetchEvent` (rejected)
+- **SW URL declared in the IDP `config.json` (e.g., `"identity_handler": { "service_worker": "/sw.js" }`).** Backed out for a privacy reason. The config file is fetched **per FedCM invocation** with the RP's `client_id` in the request path (`client_metadata`) or otherwise associated with a specific RP call; declaring the SW *inside* the config means the IDP can effectively encode RP-specific values (e.g., `/sw-for-rp-A.js` vs. `/sw-for-rp-B.js`) into the SW script URL that the browser will then register. That collapses the cross-site privacy boundary FedCM is designed to preserve — the SW (and the IDP server that serves the SW script) would learn which RP the user is interacting with, which is exactly what the config-vs-well-known two-tier file system exists to prevent.
+- **SW URL declared in the IDP well-known file (`/.well-known/web-identity`).** Backed out for operational reasons. The well-known file is the IDP's *origin-wide* contract — it must be stable, single-valued, and is fetched without any user / RP context. Encoding a SW script URL there means: (a) **deployment friction** — every SW script-URL change requires editing a top-level well-known file, which on many corporate IDPs requires a separate sign-off and rollout path than the SW build pipeline that produces `/sw.js`; (b) **no scoping** — the well-known file applies to all FedCM configs on the origin, so an IDP cannot opt different configs in/out separately; (c) **lifecycle coupling** — the SW becomes implicitly registered by the UA on first FedCM use, with no Document-owned `register()` call, leaving no natural place for the IDP page to gate registration on user state (logged-in vs. not), call `await registration` for readiness, or run `skipWaiting()` / install logic in tandem with the rest of the IDP's SW.
+- **UA-driven SW registration (browser registers / unregisters the FedCM SW on the IDP's behalf, e.g., on first FedCM invocation or when the config / well-known file changes).** Backed out because it breaks the standard `[[SERVICE-WORKERS]]` ownership model in several ways: (a) **no owning client** — every other path to `register()` runs from a Document or DedicatedWorker that owns the registration's lifecycle, but a UA-driven registration has no such owner, leaving questions like "what triggers `updatefound`?" / "when does the UA call `update()`?" / "how does `Clear-Site-Data` interact with a UA-owned registration?" without natural answers; (b) **scope semantics** — SW scope is derived from the script URL and the registering client; with no client, the spec has to invent FedCM-specific scope rules; (c) **silent SW execution** — a SW registered without the IDP page's knowledge can run install / activate handlers that the IDP did not expect or authorize, which is a footgun for IDPs that already deploy SWs for other purposes; (d) **DevTools / introspection gap** — UA-injected registrations do not naturally surface in `getRegistrations()` or in the DevTools Application > Service Workers panel without bespoke handling, making it hard for IDP developers to verify what is installed and debug failures; (e) **no upgrade story** — when the IDP wants to change its FedCM SW, there is no analog of the standard re-`register()` + `skipWaiting()` flow, so the UA has to define a new update mechanism.
 
-Allowing FedCM requests to flow through the standard `FetchEvent` pathway is the simplest
-possible design but loses every UA-set privileged property as soon as the SW does
-`fetch(event.request)` — see [*Why `fetchAugmented`*](#why-fetchaugmented). The IDP server can
-no longer tell SW-mediated FedCM requests from page-initiated XHRs, the CSRF marker
-(`Sec-Fetch-Dest: webidentity`) is gone, and `SameSite=Lax` / `Strict` cookies leak. This is
-the central reason a dedicated event and dedicated forwarding method are needed.
+The currently considered options above (opt-in flag, dedicated `registerForFedCM`, separate partition, `registration.identity` manager) all share the property that **the SW is registered through the standard `navigator.serviceWorker.register(...)` pipeline owned by an IDP page**, not declared in a config or well-known file and not injected by the UA. This keeps the SW lifecycle in the hands of IDP code that already has a controlled client, and avoids the RP-correlation channel, the well-known operational issues, and the ownership-model problems described above.
 
-## Open Questions
+### b) Keeping Lock-Down Properties Intact When `fetch` Is Called From the SW
 
-> **Note — substantial discussion in PR #815.** The following questions had non-trivial threads
-> in PR review. They are listed here so the explainer can be discussed independently of the
-> spec PR.
+When the UA constructs the FedCM internal request, it sets a deliberately hardened shape:
 
-1. **Unregistration on logout.** Should the spec require / recommend that IDPs unregister the
-   FedCM-opted SW on logout, or is the standard SW lifecycle sufficient? (Reviewer:
-   yoshisatoyanagisawa.)
-2. **Per-endpoint events vs single event.** Should the design be split into three events
-   (`accountsrequest`, `identityassertionrequest`, `disconnectrequest`) for clarity? (Reviewer:
-   yoshisatoyanagisawa; current design: single event with `endpoint` field.)
-3. **RP-correlated SW endpoints.** Are there any indirect paths by which an IDP could
-   dynamically derive an RP-keyed SW script or config (e.g., via the
-   `client_metadata` exchange)? (Reviewer: npm1.)
-4. **Augmenting header allowlist growth.** What is the threshold / process for adding new
-   headers? Reviewer-recommended block-by-default keeps the list small, but the spec needs an
-   explicit amendment process. (Reviewer: yoshisatoyanagisawa — block-by-default adopted.)
-5. **DevTools UX.** All SW-related features need a story for DevTools' Application > Service
-   Workers panel. The opt-in flag should surface visibly so IDP developers can verify they
-   opted in correctly.
-6. **Naming.** `acceptsFedCM` vs `acceptsIdentityRequest` vs `fedcmEnabled` — bikeshed.
+| Property | Value | Why |
+|---|---|---|
+| `client` | `null` | No ambient authority leaks |
+| `origin` | fresh **opaque origin** | Cookie layer treats this as cross-site to the IDP → only `SameSite=None` cookies are sent |
+| `destination` | `"webidentity"` | Stamps `Sec-Fetch-Dest: webidentity` on the wire (the FedCM CSRF marker) |
+| `redirect mode` | `"error"` | Prevents IDP-controlled redirects |
+| `referrer policy` | `"no-referrer"` | Prevents RP origin leakage to IDP |
+| `mode` | `"no-cors"` | Bypasses CORS preflight |
+| `credentials mode` | `"include"` | Sends the IDP session cookie |
+| `Accept` | UA-set per endpoint | Forces request / response shape |
+
+When the SW handles the dispatched `identityrequest` event and forwards the request to the network via `fetch(event.request)`, the internal request fields `client`, `origin`, and `destination` are not exposed (or only read-only) through the public `Request` interface today and can be reset as the request flows through the [Fetch](https://fetch.spec.whatwg.org/) `Request` constructor. If they are reset, the wire-level consequences are:
+
+| Wire | UA-direct | Naive `fetch(event.request)` |
+| --- | --- | --- |
+| `Sec-Fetch-Dest` | `webidentity` | `empty` ❌ |
+| `Sec-Fetch-Site` | `cross-site` | `same-origin` ❌ |
+| `Origin` | `null` | `https://idp.example` ❌ |
+| `Cookie` scope | `SameSite=None` only | All cookies, including `SameSite=Lax` / `Strict` ❌ |
+
+The IDP server would no longer be able to tell the SW-mediated request apart from a page-initiated XHR, the FedCM CSRF marker (`Sec-Fetch-Dest: webidentity`) would be gone, and Lax / Strict cookies would be exposed.
+
+Approaches under consideration:
+
+- **Transparent field carry-through.** Define `event.request` so that the internal request fields survive a subsequent `fetch(event.request)` invocation in the SW, without requiring any new JS-visible API.
+- **Fetch / Request spec changes.** Extend the public `Request` constructor / Fetch algorithm so that the locked-down properties round-trip through the standard SW forwarding path.
+- **Dedicated forwarding helper.** Introduce a purpose-built method on `IdentityRequestEvent` that invokes [=fetching=] directly on the UA's stored internal request, bypassing the public `Request` constructor entirely. The helper would also be the natural place to enforce the augmenting-header allowlist.
+
+Whichever approach is chosen, the spec requires the same end-state: the request that hits the wire after SW forwarding is byte-for-byte equivalent to the UA-direct request (optionally with allowlisted augmenting headers added).
+
+### c) Other Areas of Active Discussion
+
+- **Single event vs per-endpoint events.** The current design uses one `identityrequest` event with an `endpoint` field. A reviewer recommended three separate events (`accountsrequest`, `identityassertionrequest`, `disconnectrequest`). The single-event design was chosen because (a) it keeps the SW's `addEventListener` set small, (b) it lets IDPs share common framing logic across endpoints, and (c) it mirrors the precedent of `FetchEvent`. Open to revisit if there is consensus the per-endpoint design is clearer.
+- **RP-correlated SW endpoints.** A reviewer raised a privacy concern that if the SW (or its registration / config) could encode the RP identity, the SW would learn the RP and the cross-site privacy boundary FedCM aims to enforce would collapse. The current proposal does not provide any FedCM-specific mechanism for the IDP to dynamically inject an RP-keyed SW; the SW sees only what the IDP server already sees today (RP `client_id` in `id_assertion` / `disconnect` POST bodies, nothing in `accounts`). Whether any indirect path (e.g., via `client_metadata`) needs additional mitigation is still being analyzed.
+- **Augmenting header allowlist.** The SW needs to be able to attach additional headers when forwarding a FedCM request (the motivating use cases are DPoP, MFA step-up via an additional `Authorization`, and request signing). The current spec text in `index.bs` does not yet define the permitted set. The companion design notes (`Q:\cr\src\docs\local\SW-interception-of-FedCM-request.md` §3.4) propose a block-by-default allowlist with the following initial entries, pending working-group review:
+
+    | Header | Rationale |
+    |---|---|
+    | `DPoP` | Proof-of-possession of a service-worker-held key. Primary motivating use case. [RFC 9449](https://www.rfc-editor.org/rfc/rfc9449). |
+    | `Authorization` | Bearer tokens layered on top of the cookie session (MFA step-up, downstream service tokens). |
+    | `Signature` | HTTP Message Signatures ([RFC 9421](https://www.rfc-editor.org/rfc/rfc9421)). |
+    | `Signature-Input` | RFC 9421 metadata header accompanying `Signature`. |
+    | `Content-Digest` | [RFC 9530](https://www.rfc-editor.org/rfc/rfc9530) integrity digest for request body when used with HTTP Message Signatures. |
+
+    The spec also needs to define an explicit amendment process for adding new headers — file an issue with the header name, use case, applicable endpoints, security analysis, and IDP-side handling guidance; editors and security reviewers vet before the list grows.
 
 ## References
 


### PR DESCRIPTION
Feature allows Identity Providers (IDPs)  registered SW to intercept credentialed FedCM requests (accounts, id_assertion, disconnect). The Service Worker receives a dedicated IdentityRequestEvent — distinct from FetchEvent — providing a purpose-built, secure interception mechanism for federated identity flows.