### PR TITLE
Disambiguate 'success' definition reference in Bikeshed link defaults

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -64,6 +64,7 @@ spec:html; type:dfn; for:html-origin-def; text:origin
 spec:webidl; type:dfn; text:resolve
 spec:webdriver2; type:dfn; text:error
 spec:webdriver2; type:dfn; text:remote end steps
+spec:webdriver2; type:dfn; text:success
 spec:fetch; type:dfn; for:/; text:response
 spec:css-color-5; type:type; text:<color>
 spec:html; type:dfn; text:allowed to use


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/npm1/FedCM/pull/837.html" title="Last updated on Jul 15, 2026, 4:31 PM UTC (a981bcd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/FedCM/837/858d07e...npm1:a981bcd.html" title="Last updated on Jul 15, 2026, 4:31 PM UTC (a981bcd)">Diff</a>