### PR TITLE
Fix ECMAScript Object link references in WebDriver steps

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -2716,7 +2716,7 @@ The [=remote end steps=] are:
 
 The [=remote end steps=] are:
 
-1. If |parameters| is not a JSON [[ECMASCRIPT#sec-json-object|Object]], return a
+1. If |parameters| is not a JSON [[ECMASCRIPT#sec-objects|Object]], return a
     [=error|WebDriver error=] with [=error code=] [=invalid argument=].
 
 1. If no FedCM dialog is currently open, return a [=error|WebDriver error=] with
@@ -2759,7 +2759,7 @@ The [=remote end steps=] are:
 
 The [=remote end steps=] are:
 
-1. If |parameters| is not a JSON [[ECMASCRIPT#sec-json-object|Object]], return a
+1. If |parameters| is not a JSON [[ECMASCRIPT#sec-objects|Object]], return a
     [=error|WebDriver error=] with [=error code=] [=invalid argument=].
 
 1. Let |dialogButton| be the result of [=getting a property=] named
@@ -2919,7 +2919,7 @@ The [=remote end steps=] are:
 
 The [=remote end steps=] are:
 
-1. If |parameters| is not a JSON [[ECMASCRIPT#sec-json-object|Object]], return a
+1. If |parameters| is not a JSON [[ECMASCRIPT#sec-objects|Object]], return a
      [=error|WebDriver error=] with [=error code=] [=invalid argument=].
 
 1. Let |enabled| be the result of [=getting a property=] named `"enabled"` from


### PR DESCRIPTION
Fixes https://github.com/w3c-fedid/FedCM/issues/487


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/FedCM/pull/841.html" title="Last updated on Jul 23, 2026, 2:55 PM UTC (21d16be)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/FedCM/841/d50ea10...21d16be.html" title="Last updated on Jul 23, 2026, 2:55 PM UTC (21d16be)">Diff</a>