### PR TITLE
Add initial Identity Handler SW Registration Tie In.

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -59,6 +59,13 @@ spec: service-workers; urlPrefix: https://w3c.github.io/ServiceWorker/
         text: register; url: register
         text: unregister; url: unregister
         text: soft update; url: soft-update
+        text: get registration; url: get-registration
+        text: create job; url: create-job
+        text: schedule job; url: schedule-job
+        text: registration map; url: dfn-scope-to-registration-map
+    type: dfn; for: job
+        text: update via cache mode; url: dfn-job-update-via-cache-mode
+        text: referrer; url: job-referrer
 </pre>
 
 <pre class=link-defaults>
@@ -1306,8 +1313,8 @@ or failure.
             |wellKnown|.{{IdentityProviderWellKnown/provider_urls}}[0], and |globalObject|.
         1. If |allowed_config_url| is not [=url/equal=] to |configUrl|, return failure.
     1. If |wellKnown|'s {{IdentityProviderWellKnown/identity_handler}} is present, then
-        [=in parallel=], [=register the identity handler=] given |configUrl|'s [=url/origin=] and
-        |wellKnown|'s {{IdentityProviderWellKnown/identity_handler}}.
+        [=in parallel=], [=register the identity handler=] given |configUrl| and |wellKnown|'s
+        {{IdentityProviderWellKnown/identity_handler}}.
     1. Otherwise, [=in parallel=], [=unregister the identity handler=] given |configUrl|'s
         [=url/origin=].
 
@@ -1316,6 +1323,11 @@ or failure.
         |configUrl| (see [=computing the manifest URL=]), so keying the handler this way guarantees
         its registration scope can cover the endpoints it intercepts, regardless of where the
         [=well-known file=] is hosted.
+
+        Note: These steps are only reached when the [=well-known file=] was fetched successfully, so
+        a network error or an unparsable [=well-known file=] leaves an existing registration
+        unchanged. An [=IDP=] disables interception by serving a [=well-known file=] without an
+        {{IdentityProviderWellKnown/identity_handler}} member, not by making the file unavailable.
     1. Return |config|.
 
 </div>
@@ -1366,10 +1378,10 @@ Each [=/origin=] has an associated <dfn>FedCM identity-handler storage key</dfn>
 [=storage key=] the [=user agent=] constructs for that [=/origin=]'s FedCM identity handler
 [[!STORAGE]]. It MUST be distinct from the [=/origin=]'s first-party [=storage key=], such that:
 
-1. it can only be produced by the [=user agent=]; page script MUST NOT be able to cause a
+1. no Web API surface accepts this [=storage key=] or otherwise allows page script to cause a
     [=service worker registration=] to be stored under it; and
-1. it is derivable from the [=/origin=] alone, so that a later FedCM flow can recompute it to look
-    up or [=unregister=] the [=/service worker=] without any persisted state.
+1. it is derivable from the [=/origin=] alone by the [=user agent=], so that a later FedCM flow can
+    recompute it to look up or [=unregister=] the [=/service worker=] without any persisted state.
 
 Note: This isolation ensures FedCM registrations neither collide with the [=IDP=]'s ordinary
 first-party [=/service workers=] nor are reachable or removable by unrelated code sharing the
@@ -1382,34 +1394,69 @@ worker match path used for client-controlled fetches. Because a credentialed Fed
 controlling client, this ensures the request reaches only a [=/service worker=] the [=user agent=]
 registered for that specific [=IDP=].
 
+The [=user agent=] MUST serialize [=register the identity handler=] and
+[=unregister the identity handler=] per [=/origin=]: at most one of them runs at a time for a given
+[=/origin=], and their effects are observable in the order they were dispatched.
+
+Note: Concurrent FedCM requests for the same [=IDP=] can otherwise observe different
+[=well-known files=] from the HTTP cache and race to opposite conclusions about whether an identity
+handler is declared.
+
 <div algorithm>
-To <dfn>register the identity handler</dfn> given an [=/origin=] |idpOrigin| and an
+To <dfn>register the identity handler</dfn> given a [=/URL=] |configUrl| and an
 {{IdentityHandler}} |handler|, run these steps:
 
     1. Assert: These steps are running [=in parallel=].
+    1. Let |idpOrigin| be |configUrl|'s [=url/origin=].
     1. Let |scriptURL| be the result of running the [=URL parser=] on |handler|'s
-        {{IdentityHandler/service_worker}} with |idpOrigin| as the base URL.
+        {{IdentityHandler/service_worker}} with |configUrl| as the base URL.
     1. If |scriptURL| is failure, return.
     1. If |scriptURL|'s [=url/origin=] is not [=same origin=] with |idpOrigin|, return.
 
-        Note: The declared script MUST be [=same origin=] with the [=config file=]. A
-        cross-origin declaration is ignored and credentialed requests fall back to the network.
-    1. Let |scope| be the [=string=] formed by |scriptURL| with its last path segment removed.
+        Note: A cross-origin declaration is ignored, and credentialed requests fall back to the
+        network. The [=same origin=] requirement is stated normatively on
+        {{IdentityHandler/service_worker}} above.
+    1. Let |scope| be the result of running the [=URL parser=] on "`./`" with |scriptURL| as the
+        base URL.
     1. Let |storageKey| be the [=FedCM identity-handler storage key=] for |idpOrigin|.
-    1. Let |registration| be the result of running <a spec=service-workers>Match Service Worker
-        Registration</a> given |storageKey| and |scope| [[!SERVICE-WORKERS]].
-    1. If |registration| is not null and its [=active worker=]'s script url is |scriptURL|:
+    1. Let |registration| be the result of running [=get registration=] given |storageKey| and
+        |scope| [[!SERVICE-WORKERS]].
+
+        Note: [=Get registration=] matches |scope| exactly. The [=user agent=] derived that
+        [=/scope=] itself, so it does not need the longest-prefix matching that
+        [=match service worker registration=] performs on behalf of a [=/service worker client=].
+    1. If |registration| is not null, |registration|'s [=active worker=] is not null, and
+        |registration|'s [=active worker=]'s [=service worker/script url=] [=url/equals=]
+        |scriptURL|, then:
         1. [=Soft update=] |registration|.
 
-            Note: The currently [=active worker=] handles the request that triggered this
-            invocation while the [=user agent=] checks for a newer version in parallel.
+            Note: The [=user agent=] proceeds with the [=active worker=] that is already
+            registered while it checks for a newer version in parallel, so update discovery never
+            delays a FedCM request.
         1. Return.
-    1. [=Register=] a [=/service worker=] with script URL |scriptURL|, scope |scope|,
-        and [=storage key=] |storageKey|, with its update-via-cache mode set to "`all`", and wait
-        until it has an [=active worker=].
+    1. [=Unregister the identity handler=] given |idpOrigin|.
+
+        Note: This clears a registration left over from an earlier declaration, including one whose
+        script never activated and one whose [=/scope=] no longer matches because the [=IDP=] moved
+        the script. At most one [=service worker registration=] exists under |storageKey|.
+    1. Let |job| be the result of running [=create job=] with *register*, |storageKey|, |scope|,
+        |scriptURL|, null, and null.
+    1. Set |job|'s [=job/update via cache mode=] to "`all`".
 
         Note: Setting update-via-cache to "`all`" lets the [=IDP=] control update discovery through
         the script's `Cache-Control`/`ETag` headers.
+    1. Set |job|'s [=job/referrer=] to |scriptURL|.
+
+        Note: [=Register=] compares |job|'s script URL and [=/scope=] against |job|'s
+        [=job/referrer=]'s [=/origin=], which [=create job=] otherwise derives from a
+        [=/service worker client=]. A FedCM registration has no client, so the [=user agent=] sets
+        the [=job/referrer=] to the declared script URL, which is [=same origin=] with both by
+        construction.
+    1. Invoke [=schedule job=] with |job|.
+
+        Note: The job has no [=/service worker client=] and no promise, so a script that fails to
+        fetch or install is not reported to the [=IDP=]. Credentialed requests fall back to the
+        network until a later FedCM flow retries the registration.
 </div>
 
 <div algorithm>
@@ -1417,7 +1464,16 @@ To <dfn>unregister the identity handler</dfn> given an [=/origin=] |idpOrigin|, 
 
     1. Assert: These steps are running [=in parallel=].
     1. Let |storageKey| be the [=FedCM identity-handler storage key=] for |idpOrigin|.
-    1. [=Unregister=] every [=service worker registration=] whose [=storage key=] is |storageKey|.
+    1. [=list/For each=] (|entryStorageKey|, |entryScope|) of the [=registration map=]'s
+        [=map/keys=]:
+        1. If |entryStorageKey| is not |storageKey|, [=iteration/continue=].
+        1. Let |job| be the result of running [=create job=] with *unregister*, |entryStorageKey|,
+            |entryScope|, null, null, and null.
+        1. Invoke [=schedule job=] with |job|.
+
+    Note: The [=user agent=] iterates the [=registration map=] rather than [=unregister=]ing one
+    known [=/scope=], because the {{IdentityProviderWellKnown/identity_handler}} declaration, and
+    with it the declared [=/scope=], may already be gone by the time these steps run.
 </div>
 
 The [=user agent=] [=unregister the identity handler|unregisters the identity handler=] when the
@@ -1429,9 +1485,10 @@ lifetime bounds how quickly adding or removing the {{IdentityProviderWellKnown/i
 member takes effect. [=IDPs=] are encouraged to serve it with a short `Cache-Control` `max-age` so
 that enabling or disabling the identity handler propagates promptly.
 
-The [=FedCM identity-handler storage key=] is part of the [=IDP=]'s [=/origin=]'s storage: when the
-[=IDP=]'s storage is cleared (for example, via [[CLEAR-SITE-DATA]]), the [=user agent=] MUST also
-remove [=service worker registration|registrations=] stored under it, so no FedCM-specific clearing
+The [=/origin=]'s storage, for the purposes of clearing storage [[!STORAGE]] and of any
+[[CLEAR-SITE-DATA]] operation targeting that [=/origin=], includes any
+[=service worker registration|registrations=] stored under the
+[=FedCM identity-handler storage key=] for that [=/origin=], so no FedCM-specific clearing
 mechanism is required.
 
 <xmp class="idl">

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -54,6 +54,11 @@ spec: login-status; urlPrefix: https://w3c-fedid.github.io/login-status
         text: unknown; url: unknown
         text: get the login status; url: get-the-login-status
         text: set the login status; url: set-the-login-status
+spec: service-workers; urlPrefix: https://w3c.github.io/ServiceWorker/
+    type: dfn
+        text: register; url: register
+        text: unregister; url: unregister
+        text: soft update; url: soft-update
 </pre>
 
 <pre class=link-defaults>
@@ -69,6 +74,10 @@ spec:fetch; type:dfn; for:/; text:response
 spec:css-color-5; type:type; text:<color>
 spec:html; type:dfn; text:allowed to use
 spec:html; type:dfn; for:/; text:same site
+spec:service-workers; type:dfn; for:/; text:service worker
+spec:service-workers; type:dfn; for:/; text:service workers
+spec:service-workers; type:dfn; for:/; text:service worker registration
+spec:storage; type:dfn; text:storage key
 </pre>
 
 <style>
@@ -1296,6 +1305,17 @@ or failure.
         1. Let |allowed_config_url| be the result of [=computing the manifest URL=] with |provider|,
             |wellKnown|.{{IdentityProviderWellKnown/provider_urls}}[0], and |globalObject|.
         1. If |allowed_config_url| is not [=url/equal=] to |configUrl|, return failure.
+    1. If |wellKnown|'s {{IdentityProviderWellKnown/identity_handler}} is present, then
+        [=in parallel=], [=register the identity handler=] given |configUrl|'s [=url/origin=] and
+        |wellKnown|'s {{IdentityProviderWellKnown/identity_handler}}.
+    1. Otherwise, [=in parallel=], [=unregister the identity handler=] given |configUrl|'s
+        [=url/origin=].
+
+        Note: The identity handler is keyed to |configUrl|'s [=/origin=], not to the [=/origin=] the
+        [=well-known file=] was fetched from. Every credentialed endpoint is [=same origin=] with
+        |configUrl| (see [=computing the manifest URL=]), so keying the handler this way guarantees
+        its registration scope can cover the endpoints it intercepts, regardless of where the
+        [=well-known file=] is hosted.
     1. Return |config|.
 
 </div>
@@ -1316,11 +1336,114 @@ to keep their actual config files on an arbitary path while allowing the user ag
 path manipulation to fingerprint (for instance, by including the RP in the path). See
 [[#manifest-fingerprinting]].
 
+<!-- ============================================================ -->
+### Register the identity handler ### {#register-identity-handler}
+<!-- ============================================================ -->
+
+An [=IDP=] MAY declare a FedCM-specific [=/service worker=] in its [=well-known file=] using the
+{{IdentityProviderWellKnown/identity_handler}} member. When it is present, the [=user agent=]
+registers and manages this [=/service worker=] itself [[!SERVICE-WORKERS]] and dispatches
+credentialed FedCM requests to it.
+The [=IDP=] page does not register the [=/service worker=]: because credentialed FedCM requests can
+happen long after the [=IDP=] page was last visited, the [=user agent=] is responsible for ensuring
+the declared [=/service worker=] is registered and has an [=active worker=] when it is needed.
+
+The {{IdentityHandler}} members have the following semantics:
+
+<dl dfn-type="dict-member" dfn-for="IdentityHandler">
+    :   <dfn>service_worker</dfn>
+    ::  The [=/service worker=] script URL. It MUST be [=same origin=] with the [=config file=],
+        so that a party who controls a different subdomain of the [=IDP=] cannot register an
+        identity handler for this [=/origin=]. The [=user agent=] derives the registration scope
+        from this URL (the script URL with its last path segment removed).
+</dl>
+
+Note: There is no separate "enabled" switch. An [=IDP=] disables interception by removing the
+{{IdentityProviderWellKnown/identity_handler}} member from its [=well-known file=], which causes the
+[=user agent=] to [=unregister the identity handler=] and use the direct-network path.
+
+Each [=/origin=] has an associated <dfn>FedCM identity-handler storage key</dfn>: a
+[=storage key=] the [=user agent=] constructs for that [=/origin=]'s FedCM identity handler
+[[!STORAGE]]. It MUST be distinct from the [=/origin=]'s first-party [=storage key=], such that:
+
+1. it can only be produced by the [=user agent=]; page script MUST NOT be able to cause a
+    [=service worker registration=] to be stored under it; and
+1. it is derivable from the [=/origin=] alone, so that a later FedCM flow can recompute it to look
+    up or [=unregister=] the [=/service worker=] without any persisted state.
+
+Note: This isolation ensures FedCM registrations neither collide with the [=IDP=]'s ordinary
+first-party [=/service workers=] nor are reachable or removable by unrelated code sharing the
+[=IDP=]'s [=/origin=].
+
+Note: When the [=user agent=] later dispatches a credentialed request to the identity handler, it
+uses this explicit, [=user agent=]-only association between the [=IDP=] and the registration it
+created (keyed by the [=FedCM identity-handler storage key=]), rather than the implicit service
+worker match path used for client-controlled fetches. Because a credentialed FedCM request has no
+controlling client, this ensures the request reaches only a [=/service worker=] the [=user agent=]
+registered for that specific [=IDP=].
+
+<div algorithm>
+To <dfn>register the identity handler</dfn> given an [=/origin=] |idpOrigin| and an
+{{IdentityHandler}} |handler|, run these steps:
+
+    1. Assert: These steps are running [=in parallel=].
+    1. Let |scriptURL| be the result of running the [=URL parser=] on |handler|'s
+        {{IdentityHandler/service_worker}} with |idpOrigin| as the base URL.
+    1. If |scriptURL| is failure, return.
+    1. If |scriptURL|'s [=url/origin=] is not [=same origin=] with |idpOrigin|, return.
+
+        Note: The declared script MUST be [=same origin=] with the [=config file=]. A
+        cross-origin declaration is ignored and credentialed requests fall back to the network.
+    1. Let |scope| be the [=string=] formed by |scriptURL| with its last path segment removed.
+    1. Let |storageKey| be the [=FedCM identity-handler storage key=] for |idpOrigin|.
+    1. Let |registration| be the result of running <a spec=service-workers>Match Service Worker
+        Registration</a> given |storageKey| and |scope| [[!SERVICE-WORKERS]].
+    1. If |registration| is not null and its [=active worker=]'s script url is |scriptURL|:
+        1. [=Soft update=] |registration|.
+
+            Note: The currently [=active worker=] handles the request that triggered this
+            invocation while the [=user agent=] checks for a newer version in parallel.
+        1. Return.
+    1. [=Register=] a [=/service worker=] with script URL |scriptURL|, scope |scope|,
+        and [=storage key=] |storageKey|, with its update-via-cache mode set to "`all`", and wait
+        until it has an [=active worker=].
+
+        Note: Setting update-via-cache to "`all`" lets the [=IDP=] control update discovery through
+        the script's `Cache-Control`/`ETag` headers.
+</div>
+
+<div algorithm>
+To <dfn>unregister the identity handler</dfn> given an [=/origin=] |idpOrigin|, run these steps:
+
+    1. Assert: These steps are running [=in parallel=].
+    1. Let |storageKey| be the [=FedCM identity-handler storage key=] for |idpOrigin|.
+    1. [=Unregister=] every [=service worker registration=] whose [=storage key=] is |storageKey|.
+</div>
+
+The [=user agent=] [=unregister the identity handler|unregisters the identity handler=] when the
+[=IDP=] removes the {{IdentityProviderWellKnown/identity_handler}} member from its
+[=well-known file=].
+
+Note: Because the [=well-known file=] is fetched subject to ordinary HTTP caching, its freshness
+lifetime bounds how quickly adding or removing the {{IdentityProviderWellKnown/identity_handler}}
+member takes effect. [=IDPs=] are encouraged to serve it with a short `Cache-Control` `max-age` so
+that enabling or disabling the identity handler propagates promptly.
+
+The [=FedCM identity-handler storage key=] is part of the [=IDP=]'s [=/origin=]'s storage: when the
+[=IDP=]'s storage is cleared (for example, via [[CLEAR-SITE-DATA]]), the [=user agent=] MUST also
+remove [=service worker registration|registrations=] stored under it, so no FedCM-specific clearing
+mechanism is required.
+
 <xmp class="idl">
 dictionary IdentityProviderWellKnown {
   sequence<USVString> provider_urls;
   USVString accounts_endpoint;
   USVString login_url;
+  IdentityHandler identity_handler;
+};
+
+dictionary IdentityHandler {
+  required USVString service_worker;
 };
 
 dictionary IdentityProviderIcon {
@@ -2134,6 +2257,10 @@ The {{IdentityProviderWellKnown}} JSON object has the following semantics:
     ::  A URL that points to the same location as the {{IdentityProviderAPIConfig/accounts_endpoint}} in [[#idp-api-config-file]]s.
     :   <dfn>login_url</dfn>
     ::  A URL that points to the same location as the {{IdentityProviderAPIConfig/login_url}} in [[#idp-api-config-file]]s.
+    :   <dfn>identity_handler</dfn>
+    ::  An optional {{IdentityHandler}} declaring a FedCM-specific [=/service worker=] that the
+        [=user agent=] registers and manages in order to intercept credentialed FedCM requests.
+        See [[#register-identity-handler]].
 </dl>
 
 Either {{IdentityProviderWellKnown/provider_urls}} or both

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -59,13 +59,13 @@ spec: service-workers; urlPrefix: https://w3c.github.io/ServiceWorker/
         text: register; url: register
         text: unregister; url: unregister
         text: soft update; url: soft-update
-        text: get registration; url: get-registration
         text: create job; url: create-job
         text: schedule job; url: schedule-job
         text: registration map; url: dfn-scope-to-registration-map
     type: dfn; for: job
         text: update via cache mode; url: dfn-job-update-via-cache-mode
         text: referrer; url: job-referrer
+        text: worker type; url: dfn-job-worker-type
 </pre>
 
 <pre class=link-defaults>
@@ -85,6 +85,9 @@ spec:service-workers; type:dfn; for:/; text:service worker
 spec:service-workers; type:dfn; for:/; text:service workers
 spec:service-workers; type:dfn; for:/; text:service worker registration
 spec:storage; type:dfn; text:storage key
+spec:html; type:dfn; text:parallel queue
+spec:html; type:dfn; text:start a new parallel queue
+spec:html; type:dfn; text:enqueue steps
 </pre>
 
 <style>
@@ -1312,11 +1315,13 @@ or failure.
         1. Let |allowed_config_url| be the result of [=computing the manifest URL=] with |provider|,
             |wellKnown|.{{IdentityProviderWellKnown/provider_urls}}[0], and |globalObject|.
         1. If |allowed_config_url| is not [=url/equal=] to |configUrl|, return failure.
+    1. Let |idpOrigin| be |configUrl|'s [=url/origin=].
     1. If |wellKnown|'s {{IdentityProviderWellKnown/identity_handler}} is present, then
-        [=in parallel=], [=register the identity handler=] given |configUrl| and |wellKnown|'s
+        [=enqueue steps=] to |idpOrigin|'s [=identity handler queue=] to
+        [=register the identity handler=] given |configUrl| and |wellKnown|'s
         {{IdentityProviderWellKnown/identity_handler}}.
-    1. Otherwise, [=in parallel=], [=unregister the identity handler=] given |configUrl|'s
-        [=url/origin=].
+    1. Otherwise, [=enqueue steps=] to |idpOrigin|'s [=identity handler queue=] to
+        [=unregister the identity handler=] given |idpOrigin|.
 
         Note: The identity handler is keyed to |configUrl|'s [=/origin=], not to the [=/origin=] the
         [=well-known file=] was fetched from. Every credentialed endpoint is [=same origin=] with
@@ -1328,6 +1333,10 @@ or failure.
         a network error or an unparsable [=well-known file=] leaves an existing registration
         unchanged. An [=IDP=] disables interception by serving a [=well-known file=] without an
         {{IdentityProviderWellKnown/identity_handler}} member, not by making the file unavailable.
+
+        Note: These steps do not wait for the registration to complete. A concurrent FedCM request
+        for the same [=IDP=] runs on the same [=identity handler queue=], so it observes a
+        consistent registration state rather than racing this one.
     1. Return |config|.
 
 </div>
@@ -1354,33 +1363,25 @@ path manipulation to fingerprint (for instance, by including the RP in the path)
 
 An [=IDP=] MAY declare a FedCM-specific [=/service worker=] in its [=well-known file=] using the
 {{IdentityProviderWellKnown/identity_handler}} member. When it is present, the [=user agent=]
-registers and manages this [=/service worker=] itself [[!SERVICE-WORKERS]] and dispatches
-credentialed FedCM requests to it.
-The [=IDP=] page does not register the [=/service worker=]: because credentialed FedCM requests can
-happen long after the [=IDP=] page was last visited, the [=user agent=] is responsible for ensuring
-the declared [=/service worker=] is registered and has an [=active worker=] when it is needed.
-
-The {{IdentityHandler}} members have the following semantics:
-
-<dl dfn-type="dict-member" dfn-for="IdentityHandler">
-    :   <dfn>service_worker</dfn>
-    ::  The [=/service worker=] script URL. It MUST be [=same origin=] with the [=config file=],
-        so that a party who controls a different subdomain of the [=IDP=] cannot register an
-        identity handler for this [=/origin=]. The [=user agent=] derives the registration scope
-        from this URL (the script URL with its last path segment removed).
-</dl>
+registers and manages this [=/service worker=] itself and dispatches credentialed FedCM requests to
+it. The [=IDP=] page does not register the [=/service worker=]: because credentialed FedCM requests
+can happen long after the [=IDP=] page was last visited, the [=user agent=] is responsible for
+ensuring the declared [=/service worker=] is registered and has an [=active worker=] when it is
+needed.
 
 Note: There is no separate "enabled" switch. An [=IDP=] disables interception by removing the
 {{IdentityProviderWellKnown/identity_handler}} member from its [=well-known file=], which causes the
 [=user agent=] to [=unregister the identity handler=] and use the direct-network path.
 
 Each [=/origin=] has an associated <dfn>FedCM identity-handler storage key</dfn>: a
-[=storage key=] the [=user agent=] constructs for that [=/origin=]'s FedCM identity handler
-[[!STORAGE]]. It MUST be distinct from the [=/origin=]'s first-party [=storage key=], such that:
+[=storage key=] the [=user agent=] constructs for that [=/origin=]'s FedCM identity handler.
+It MUST be distinct from the [=/origin=]'s first-party [=storage key=], such that:
 
-1. no Web API surface accepts this [=storage key=] or otherwise allows page script to cause a
+1. The two do not [=storage key/equals|compare as equal=], so that a [=registration map=] lookup
+    given one of them never returns a [=service worker registration=] stored under the other;
+1. No Web API surface accepts this [=storage key=] or otherwise allows page script to cause a
     [=service worker registration=] to be stored under it; and
-1. it is derivable from the [=/origin=] alone by the [=user agent=], so that a later FedCM flow can
+1. It is derivable from the [=/origin=] alone by the [=user agent=], so that a later FedCM flow can
     recompute it to look up or [=unregister=] the [=/service worker=] without any persisted state.
 
 Note: This isolation ensures FedCM registrations neither collide with the [=IDP=]'s ordinary
@@ -1394,9 +1395,11 @@ worker match path used for client-controlled fetches. Because a credentialed Fed
 controlling client, this ensures the request reaches only a [=/service worker=] the [=user agent=]
 registered for that specific [=IDP=].
 
-The [=user agent=] MUST serialize [=register the identity handler=] and
-[=unregister the identity handler=] per [=/origin=]: at most one of them runs at a time for a given
-[=/origin=], and their effects are observable in the order they were dispatched.
+Each [=/origin=] has an associated <dfn>identity handler queue</dfn>, which is a
+[=parallel queue=] the [=user agent=] [=starts a new parallel queue|starts=] the first time it is
+needed. [=Register the identity handler=] and [=unregister the identity handler=] run on it, so at
+most one of them runs at a time for a given [=/origin=] and their effects are observable in the
+order they were enqueued.
 
 Note: Concurrent FedCM requests for the same [=IDP=] can otherwise observe different
 [=well-known files=] from the HTTP cache and race to opposite conclusions about whether an identity
@@ -1406,7 +1409,8 @@ handler is declared.
 To <dfn>register the identity handler</dfn> given a [=/URL=] |configUrl| and an
 {{IdentityHandler}} |handler|, run these steps:
 
-    1. Assert: These steps are running [=in parallel=].
+    1. Assert: These steps are running on |configUrl|'s [=url/origin=]'s
+        [=identity handler queue=].
     1. Let |idpOrigin| be |configUrl|'s [=url/origin=].
     1. Let |scriptURL| be the result of running the [=URL parser=] on |handler|'s
         {{IdentityHandler/service_worker}} with |configUrl| as the base URL.
@@ -1414,33 +1418,49 @@ To <dfn>register the identity handler</dfn> given a [=/URL=] |configUrl| and an
     1. If |scriptURL|'s [=url/origin=] is not [=same origin=] with |idpOrigin|, return.
 
         Note: A cross-origin declaration is ignored, and credentialed requests fall back to the
-        network. The [=same origin=] requirement is stated normatively on
-        {{IdentityHandler/service_worker}} above.
+        network.
     1. Let |scope| be the result of running the [=URL parser=] on "`./`" with |scriptURL| as the
         base URL.
-    1. Let |storageKey| be the [=FedCM identity-handler storage key=] for |idpOrigin|.
-    1. Let |registration| be the result of running [=get registration=] given |storageKey| and
-        |scope| [[!SERVICE-WORKERS]].
 
-        Note: [=Get registration=] matches |scope| exactly. The [=user agent=] derived that
-        [=/scope=] itself, so it does not need the longest-prefix matching that
-        [=match service worker registration=] performs on behalf of a [=/service worker client=].
+        Note: This matches the [=/scope=] that [[!SERVICE-WORKERS]] derives for a page-initiated
+        registration that does not pass one explicitly.
+    1. Let |storageKey| be the [=FedCM identity-handler storage key=] for |idpOrigin|.
+    1. Let |registration| be the result of running [=match service worker registration=] given
+        |storageKey| and |scriptURL| [[!SERVICE-WORKERS]].
+
+        Note: [=Match service worker registration=] returns the registration whose [=/scope=] is
+        the longest prefix of |scriptURL|. The [=user agent=] keeps at most one
+        [=service worker registration=] under |storageKey| (see the teardown step below), so that
+        is the identity handler's registration if one exists. It is used here in preference to the
+        [=registration map=] lookups it wraps, because it is the entry point [[!SERVICE-WORKERS]]
+        exports for this purpose.
     1. If |registration| is not null, |registration|'s [=active worker=] is not null, and
         |registration|'s [=active worker=]'s [=service worker/script url=] [=url/equals=]
         |scriptURL|, then:
         1. [=Soft update=] |registration|.
-
-            Note: The [=user agent=] proceeds with the [=active worker=] that is already
-            registered while it checks for a newer version in parallel, so update discovery never
-            delays a FedCM request.
         1. Return.
+
+        Note: The [=user agent=] proceeds with the [=active worker=] that is already registered and
+        checks for a newer version in parallel, so update discovery never delays a FedCM request.
+        Because [=job/update via cache mode=] is "`all`", how often that check reaches the network
+        is governed by the script's `Cache-Control` and `ETag` headers, which the [=IDP=] controls.
+        Running it on each invocation, rather than relying on the [=/service worker=]'s own
+        staleness threshold, is what lets an [=IDP=] ship a fix at an unchanged script URL without
+        waiting a day for it to be picked up.
     1. [=Unregister the identity handler=] given |idpOrigin|.
 
-        Note: This clears a registration left over from an earlier declaration, including one whose
-        script never activated and one whose [=/scope=] no longer matches because the [=IDP=] moved
-        the script. At most one [=service worker registration=] exists under |storageKey|.
+        Note: This step matters most when |registration| is null. If the [=IDP=] moves the declared
+        script to a path outside the previous [=/scope=], the lookup misses while the earlier
+        registration is still stored under |storageKey|. Tearing down first also clears a
+        registration whose script never activated, and keeps at most one
+        [=service worker registration=] under |storageKey|.
     1. Let |job| be the result of running [=create job=] with *register*, |storageKey|, |scope|,
         |scriptURL|, null, and null.
+    1. Set |job|'s [=job/worker type=] to "`classic`".
+
+        Note: [=Create job=] does not initialize [=job/worker type=], and [=register=] compares it
+        against the newest worker's type. {{IdentityHandler}} has no member for selecting a module
+        worker, so the [=user agent=] always registers a classic one.
     1. Set |job|'s [=job/update via cache mode=] to "`all`".
 
         Note: Setting update-via-cache to "`all`" lets the [=IDP=] control update discovery through
@@ -1462,23 +1482,25 @@ To <dfn>register the identity handler</dfn> given a [=/URL=] |configUrl| and an
 <div algorithm>
 To <dfn>unregister the identity handler</dfn> given an [=/origin=] |idpOrigin|, run these steps:
 
-    1. Assert: These steps are running [=in parallel=].
+    1. Assert: These steps are running on |idpOrigin|'s [=identity handler queue=].
     1. Let |storageKey| be the [=FedCM identity-handler storage key=] for |idpOrigin|.
+    1. Let |scopes| be an empty [=list=].
     1. [=list/For each=] (|entryStorageKey|, |entryScope|) of the [=registration map=]'s
         [=map/keys=]:
-        1. If |entryStorageKey| is not |storageKey|, [=iteration/continue=].
-        1. Let |job| be the result of running [=create job=] with *unregister*, |entryStorageKey|,
-            |entryScope|, null, null, and null.
+        1. If |entryStorageKey| is |storageKey|, [=list/append=] |entryScope| to |scopes|.
+    1. [=list/For each=] |scope| of |scopes|:
+        1. Let |job| be the result of running [=create job=] with *unregister*, |storageKey|,
+            |scope|, null, null, and null.
         1. Invoke [=schedule job=] with |job|.
 
-    Note: The [=user agent=] iterates the [=registration map=] rather than [=unregister=]ing one
-    known [=/scope=], because the {{IdentityProviderWellKnown/identity_handler}} declaration, and
-    with it the declared [=/scope=], may already be gone by the time these steps run.
+    Note: The [=user agent=] collects the matching [=/scopes=] before scheduling any job, rather
+    than scheduling while iterating the [=registration map=]. It iterates at all, rather than
+    [=unregister=]ing one known [=/scope=], because the
+    {{IdentityProviderWellKnown/identity_handler}} declaration, and with it the declared
+    [=/scope=], may already be gone by the time these steps run. [=Register the identity handler=]
+    keeps at most one entry under |storageKey|, so |scopes| is not expected to hold more than one
+    [=/scope=].
 </div>
-
-The [=user agent=] [=unregister the identity handler|unregisters the identity handler=] when the
-[=IDP=] removes the {{IdentityProviderWellKnown/identity_handler}} member from its
-[=well-known file=].
 
 Note: Because the [=well-known file=] is fetched subject to ordinary HTTP caching, its freshness
 lifetime bounds how quickly adding or removing the {{IdentityProviderWellKnown/identity_handler}}
@@ -2318,6 +2340,17 @@ The {{IdentityProviderWellKnown}} JSON object has the following semantics:
     ::  An optional {{IdentityHandler}} declaring a FedCM-specific [=/service worker=] that the
         [=user agent=] registers and manages in order to intercept credentialed FedCM requests.
         See [[#register-identity-handler]].
+</dl>
+
+The {{IdentityHandler}} JSON object has the following semantics:
+
+<dl dfn-type="dict-member" dfn-for="IdentityHandler">
+    :   <dfn>service_worker</dfn>
+    ::  The [=/service worker=] script URL, which is [=same origin=] with the [=config file=], so
+        that a party who controls a different subdomain of the [=IDP=] cannot declare an identity
+        handler for this [=/origin=]. The [=user agent=] derives the registration [=/scope=] from
+        this URL, and ignores the declaration when it is cross-origin. See
+        [=register the identity handler=].
 </dl>
 
 Either {{IdentityProviderWellKnown/provider_urls}} or both


### PR DESCRIPTION
This change starts to update and split the proposed changes in #815. Specifically it focuses on the SW registration aspects and adds the `identity_handler` declaration to the well-known file and the registration lifecycle for it: register on config fetch, unregister when the declaration goes away, and clear alongside the rest of the IDP's storage. Registration is UA managed under a storage key isolated from the IDP's first-party one, which is where #833 looks to have landed on isolation.

Dispatch, the event IDL, and the security and privacy considerations will follow in separate PRs.

For additional context the full proposal [explainer](https://github.com/w3c-fedid/identity-handler/blob/main/identity-handler-explainer.md) may also help.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/FedCM/pull/842.html" title="Last updated on Aug 1, 2026, 2:01 AM UTC (c7360cb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-fedid/FedCM/842/26a12eb...c7360cb.html" title="Last updated on Aug 1, 2026, 2:01 AM UTC (c7360cb)">Diff</a>